### PR TITLE
[DLT-005] Load foundational context for personality and user knowledge

### DIFF
--- a/docs/delta-designs/DLT-005.md
+++ b/docs/delta-designs/DLT-005.md
@@ -1,0 +1,368 @@
+# Design: DLT-005 - Load foundational context for personality and user knowledge
+
+**Delta Spec**: [../delta-specs/DLT-005.md](../delta-specs/DLT-005.md)
+**Status**: Approved
+
+## Purpose
+
+This document explains the design rationale for this delta: the modeling choices, data flow, system behavior, and architectural approach.
+
+After implementation, the "Detected Impacts" section will guide reconciliation into feature design docs.
+
+## Problem Context
+
+The assistant needs a consistent personality, knowledge of the user, and operational guidelines — regardless of which memories are retrieved for a given conversation. Without foundational context, the agent starts each session as a blank slate, relying entirely on dynamically retrieved memories (future DLT-006) for personality and user knowledge.
+
+Three concerns drive the design:
+
+1. **Identity consistency**: The agent should have the same tone, personality, and behavioral guidelines every time
+2. **User knowledge baseline**: Known facts about the user (name, preferences, projects) should always be available, not contingent on memory retrieval relevance
+3. **Transparency**: Users should be able to see and edit exactly what shapes the agent's behavior — no hidden configuration
+
+**Constraints:**
+- Context files must be human-readable markdown in the workspace (user-editable)
+- Context is layered ON TOP of the SDK's default Claude Code system prompt, not replacing it
+- Files are loaded once at startup — no hot-reload mid-session (R8, R9 are Out)
+- Bootstrap hook must be idempotent (safe to run every launch)
+
+**Interactions:**
+- Workspace bootstrap (DLT-023) must run first to create the workspace directory
+- DLT-018 (update core context files from conversations) will consume the file paths and format established here
+- The coordinator (core architecture) receives the assembled prompt as a constructor parameter
+
+## Design Overview
+
+A new `context.py` module owns the entire context domain: file path definitions, default template content, a bootstrap hook for first-run initialization, and a loader that reads and assembles files into a system prompt string. The hook creates `context/` and writes default templates on first run, then loads the files and stores the assembled prompt in `ctx.extras["system_prompt"]`. The entry point reads this extra and passes it to the Coordinator, which wraps it in a `SystemPromptPreset` to append it to the SDK's default Claude Code prompt.
+
+As part of this delta, `workspace_hook` is extracted from `bootstrap.py` into a new `workspace.py` module, establishing the pattern that each subsystem owns its bootstrap hook internally. `bootstrap.py` becomes purely the mechanism.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                          __main__.py                              │
+│                                                                  │
+│  bootstrap.register("workspace", workspace_hook)  ← workspace.py │
+│  bootstrap.register("context", context_hook)      ← context.py   │
+│  bootstrap.register("sessions", session_recovery_hook)            │
+│                                                                  │
+│  await bootstrap.run()                                           │
+│                                                                  │
+│  system_prompt = bootstrap.extras.get("system_prompt")           │
+│  Coordinator(..., system_prompt=system_prompt)                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Shape
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **S1** | **Context bootstrap hook** — A `context_hook` function in a new `context.py` module that creates `context/` directory under workspace root and writes default template files (SOUL.md, USER.md, AGENTS.md) on first run. Skips existing files. Registered after workspace hook in `__main__.py`. | |
+| **S2** | **Context loader** — A `load_context` function in `context.py` that reads the three context files, handles missing/empty/unreadable files gracefully (logs warnings per DES-002), prepends a hard-coded preamble explaining the context system, and concatenates file contents wrapped in XML tags (`<soul>`, `<user>`, `<agents>`) in order: SOUL → USER → AGENTS. Returns the assembled string. Called by the hook, result stored in `ctx.extras["system_prompt"]`. | |
+| **S3** | **Coordinator system prompt integration** — Coordinator accepts a `system_prompt: str | None` parameter. When present, wraps it in `SystemPromptPreset(type="preset", preset="claude_code", append=context_string)` and sets it on `ClaudeAgentOptions.system_prompt`. `__main__.py` reads `bootstrap.extras["system_prompt"]` and passes to Coordinator. | |
+| **S4** | **Default template content** — Meaningful starter content as module-level constants in `context.py`: SOUL.md with personality traits + dialogue encouragement, USER.md with user-discovery prompt, AGENTS.md explaining its purpose as behavioral instructions. | |
+| **S5** | **Workspace hook extraction** — Move `workspace_hook` from `bootstrap.py` to a new `workspace.py` module. Update imports in `__main__.py`. Establishes the pattern: each subsystem owns its hook internally. `bootstrap.py` becomes purely the mechanism (Bootstrap class, BootstrapContext, BootstrapError, BootstrapHook type). | |
+
+### Flagged Unknowns
+
+None.
+
+## Components
+
+### Implementation Structure
+
+| Layer/Component | Responsibility | Key Decisions |
+|-----------------|----------------|---------------|
+| `src/tachikoma/context.py` | Context file management: file path definitions, default template constants, bootstrap hook (`context_hook`), and context loader (`load_context`) | New module; single home for the context domain. DLT-018 will import from here. |
+| `src/tachikoma/workspace.py` | Workspace directory creation hook (`workspace_hook`) | Extracted from `bootstrap.py`; owns the workspace initialization concern |
+| `src/tachikoma/bootstrap.py` | Bootstrap mechanism only: `Bootstrap`, `BootstrapContext`, `BootstrapHook`, `BootstrapError` | `workspace_hook` removed; purely mechanism now |
+| `src/tachikoma/coordinator.py` | Wraps `ClaudeSDKClient`; now accepts `system_prompt` parameter | `SystemPromptPreset` integration via `ClaudeAgentOptions.system_prompt` |
+| `src/tachikoma/__main__.py` | Entry point: registers hooks, reads `system_prompt` from extras, passes to Coordinator | Hook registration order: workspace → context → sessions |
+
+### Cross-Layer Contracts
+
+```mermaid
+sequenceDiagram
+    participant Main as __main__.py
+    participant Boot as Bootstrap
+    participant WH as workspace_hook
+    participant CH as context_hook
+    participant Loader as load_context
+    participant Coord as Coordinator
+    participant SDK as ClaudeSDKClient
+
+    Main->>Boot: register("workspace", workspace_hook)
+    Main->>Boot: register("context", context_hook)
+    Main->>Boot: register("sessions", session_recovery_hook)
+    Main->>Boot: await run()
+
+    Boot->>WH: workspace_hook(ctx)
+    WH-->>Boot: workspace dir ready
+
+    Boot->>CH: context_hook(ctx)
+    CH->>CH: create context/ dir + default files (if missing)
+    CH->>Loader: load_context(workspace_path)
+    Loader-->>CH: assembled prompt string (or None)
+    CH->>CH: ctx.extras["system_prompt"] = prompt
+    CH-->>Boot: done
+
+    Boot-->>Main: run() complete
+
+    Main->>Main: system_prompt = bootstrap.extras.get("system_prompt")
+    Main->>Coord: Coordinator(..., system_prompt=system_prompt)
+    Coord->>SDK: ClaudeAgentOptions(system_prompt=SystemPromptPreset(..., append=system_prompt))
+```
+
+**Integration Points:**
+- context_hook ↔ Bootstrap: receives `BootstrapContext`, stores result in `ctx.extras["system_prompt"]`
+- `__main__.py` ↔ Bootstrap: reads `bootstrap.extras.get("system_prompt")` after `run()`
+- `__main__.py` ↔ Coordinator: passes `system_prompt` string to constructor
+- Coordinator ↔ SDK: wraps string in `SystemPromptPreset` and sets on `ClaudeAgentOptions`
+
+### Shared Logic
+
+- **Context file paths**: Defined in `context.py` as functions of the workspace path. DLT-018 will import these to know where to write updates.
+- **Default template content**: Module-level string constants in `context.py`. DLT-018 may reference these for understanding the file format.
+
+## Modeling
+
+The domain model is minimal — this delta introduces no persistent entities:
+
+```
+context.py
+├── CONTEXT_DIR_NAME = "context"
+├── CONTEXT_FILES: ordered list mapping filename → XML tag name → default content
+│   ├── ("SOUL.md",   "soul",   DEFAULT_SOUL_CONTENT)
+│   ├── ("USER.md",   "user",   DEFAULT_USER_CONTENT)
+│   └── ("AGENTS.md", "agents", DEFAULT_AGENTS_CONTENT)
+├── CONTEXT_PREAMBLE (str constant)
+├── context_hook(ctx: BootstrapContext) → None
+└── load_context(workspace_path: Path) → str | None
+```
+
+The three context files are plain markdown managed by the user. The system reads them as strings and assembles them into a single prompt string. No structured parsing, no metadata extraction — just string concatenation with XML delimiters.
+
+`load_context` returns `str | None`: a non-empty assembled string when at least one file has content, or `None` when all files are missing/empty (so the coordinator can skip setting the system prompt entirely).
+
+## Data Flow
+
+### Bootstrap flow (context initialization)
+
+```
+1. context_hook receives BootstrapContext
+2. Reads workspace_path from ctx.settings_manager.settings.workspace.path
+3. Computes context_path = workspace_path / "context"
+4. Creates context_path directory if missing (exist_ok=True)
+5. For each of [SOUL.md, USER.md, AGENTS.md]:
+   a. Check if file exists at context_path / filename
+   b. If missing → write default template content
+   c. If exists → skip (idempotent)
+6. Calls load_context(workspace_path) to assemble the prompt
+7. If result is not None → stores in ctx.extras["system_prompt"]
+```
+
+### Context loading and assembly
+
+```
+1. load_context receives workspace_path
+2. Computes context_path = workspace_path / "context"
+3. For each file in order (SOUL.md, USER.md, AGENTS.md):
+   a. Attempt to read file contents
+   b. If missing → log warning, skip
+   c. If empty → skip (no section added, no warning)
+   d. If unreadable (PermissionError, OSError) → log warning, skip
+   e. If has content → wrap in XML tags and collect
+4. If no sections collected → return None
+5. Prepend hard-coded preamble to collected sections
+6. Return assembled string
+```
+
+### Assembled prompt structure
+
+```
+[CONTEXT_PREAMBLE — explains the context system, file purposes, user-editability]
+
+<soul>
+[contents of SOUL.md]
+</soul>
+
+<user>
+[contents of USER.md]
+</user>
+
+<agents>
+[contents of AGENTS.md]
+</agents>
+```
+
+### Startup flow (how prompt reaches the agent)
+
+```
+1. __main__.py registers hooks: workspace → context → sessions
+2. Bootstrap.run() executes hooks in order
+3. After run(), __main__.py reads bootstrap.extras.get("system_prompt")
+4. Passes system_prompt to Coordinator constructor
+5. Coordinator stores system_prompt
+6. On __aenter__, creates ClaudeSDKClient with options:
+   - If system_prompt is not None:
+     SystemPromptPreset(type="preset", preset="claude_code", append=system_prompt)
+   - If system_prompt is None:
+     system_prompt field left as None (SDK default)
+7. ClaudeSDKClient receives options with appended context
+```
+
+## Key Decisions
+
+### Subsystem-owned hooks (pattern change)
+
+**Choice**: Each subsystem defines its own bootstrap hook in its own module. `workspace_hook` moves to `workspace.py`, `context_hook` lives in `context.py`, `session_recovery_hook` already lives in `sessions/hooks.py`.
+**Why**: Separation of concerns — `bootstrap.py` should be the mechanism, not a bag of unrelated hooks. Each subsystem owns its initialization logic. This also gives downstream deltas (DLT-018, DLT-020) clean import targets.
+**Sources**: User decision during design interview; sessions package already follows this pattern.
+**Options Researched**: Co-locating all hooks in `bootstrap.py` (simpler but conflates mechanism with concerns).
+**Why This Over Alternatives**: Consistency with existing sessions pattern; cleaner module boundaries; better for DLT-018 reuse.
+
+**Consequences**:
+- Pro: Clean module boundaries — each subsystem is self-contained
+- Pro: `bootstrap.py` stays focused and small
+- Pro: DLT-018 can import `context.py` directly
+- Con: One more module per subsystem (minor; each is small)
+
+### XML tags for section delimiters
+
+**Choice**: Wrap each file's content in XML tags (`<soul>`, `<user>`, `<agents>`) in the assembled prompt.
+**Why**: XML tags provide clear, unambiguous boundaries that LLMs can reliably parse. They are commonly used in system prompts to delineate sections and are less likely to be confused with file content than markdown headings.
+**Sources**: User decision during design interview; common LLM prompt engineering practice.
+**Options Researched**: Markdown headings (`# SOUL`), simple separators (`---`), XML tags.
+**Why This Over Alternatives**: Markdown headings could collide with content in the files themselves. Simple separators lack semantic meaning. XML tags are explicit and widely used for prompt section delineation.
+
+**Consequences**:
+- Pro: Unambiguous section boundaries
+- Pro: Agent can easily reference "the content in `<soul>`" for self-awareness
+- Con: Slightly more verbose than markdown headings (negligible)
+
+### SystemPromptPreset with append (not replace)
+
+**Choice**: Use `SystemPromptPreset(type="preset", preset="claude_code", append=context_string)` to layer context on top of the SDK's default prompt.
+**Why**: The SDK's default Claude Code prompt includes tool-use instructions, safety guidelines, and agentic loop behaviors that are essential for the agent to function correctly. Replacing it would require replicating all of that. Appending is the SDK's designed mechanism for this use case.
+**Sources**: SDK source code inspection — `ClaudeAgentOptions.system_prompt` accepts `str | SystemPromptPreset | None`; `SystemPromptPreset` is a `TypedDict` with `type`, `preset`, and `append` fields. Importable from `claude_agent_sdk.types`.
+**Options Researched**: Full replacement via plain string, `SystemPromptPreset` with append.
+**Why This Over Alternatives**: Full replacement loses all SDK built-in behaviors (tool use, safety, agentic loop). Append preserves them and is the intended extension mechanism.
+
+**Consequences**:
+- Pro: Preserves all SDK default behaviors
+- Pro: Uses the SDK's designed extension point
+- Pro: Future SDK updates to the default prompt automatically apply
+- Con: We don't control the full system prompt (acceptable — we shouldn't)
+
+### Context loader returns None for empty state
+
+**Choice**: `load_context` returns `str | None` — `None` when all files are missing or empty.
+**Why**: When no context files have content, there's nothing to append. Returning `None` lets the coordinator skip setting `system_prompt` entirely, which means the SDK uses its vanilla default prompt. This avoids appending just the preamble with no actual content.
+
+**Consequences**:
+- Pro: Clean no-op when no context exists
+- Pro: Coordinator doesn't need to check for empty strings
+- Con: None (the distinction is clear)
+
+### Empty files are silent, missing/unreadable files warn
+
+**Choice**: Empty files are silently skipped (no warning), while missing and unreadable files log a warning.
+**Why**: The spec's R4 groups "missing, empty, or unreadable" together, but the conditions have different semantics. A missing file is unexpected after the bootstrap hook has run (something deleted it). An unreadable file is an OS-level error. Both warrant a warning. An empty file, however, is a deliberate user action — the user opened the file and removed all content, or explicitly chose not to fill it in. Warning on intentional behavior would be noisy. This design refines R4's blanket treatment into context-appropriate handling.
+
+**Consequences**:
+- Pro: No false alarms for intentional user choices
+- Pro: Warnings still fire for genuinely unexpected conditions (missing, permissions)
+- Con: Slight divergence from R4 wording (but aligns with R4's intent)
+
+### Fatal vs graceful error boundary
+
+**Choice**: Directory creation failures in `context_hook` are fatal (abort startup via BootstrapError). File read failures in `load_context` are graceful (log and continue).
+**Why**: If the `context/` directory cannot be created, something is fundamentally wrong with the filesystem — the same class of failure that makes `workspace_hook` fatal. The agent cannot function if basic directory operations fail. File read failures, on the other hand, are localized — one unreadable file should not prevent the agent from starting with the remaining files.
+
+**Consequences**:
+- Pro: Consistent with workspace_hook behavior for directory-level failures
+- Pro: File-level failures degrade gracefully per R4
+- Con: None (clear boundary between infrastructure failure and content failure)
+
+## System Behavior
+
+### Scenario: First launch — no context directory
+
+**Given**: The workspace exists but no `context/` directory
+**When**: The context hook runs during bootstrap
+**Then**: `context/` is created along with SOUL.md, USER.md, and AGENTS.md containing default template content. The loader reads all three files and assembles the system prompt with the preamble and XML-tagged sections.
+**Rationale**: First-run initialization creates meaningful defaults that prompt the agent to engage in a personality/preference discovery conversation with the user.
+
+### Scenario: Subsequent launch — all files exist and have content
+
+**Given**: All three context files exist with user-customized content
+**When**: The context hook runs
+**Then**: The hook skips file creation (idempotent). The loader reads files and assembles the system prompt with the user's content.
+**Rationale**: Idempotency — existing files are never overwritten.
+
+### Scenario: One context file is missing
+
+**Given**: SOUL.md and AGENTS.md exist, but USER.md was accidentally deleted
+**When**: The context hook runs
+**Then**: The hook recreates USER.md with default content. The loader reads all three files.
+**Rationale**: Per R3 (AC: only missing file is created with default content) — selective creation preserves existing files while recovering missing ones.
+
+### Scenario: One context file is empty
+
+**Given**: All three files exist, but USER.md is empty (0 bytes)
+**When**: The loader reads context files
+**Then**: SOUL.md and AGENTS.md are wrapped in XML tags; USER.md is skipped (no `<user>` section in output). No warning is logged for empty files.
+**Rationale**: An empty file is a deliberate user action, not an error. The system respects it by omitting that section.
+
+### Scenario: Context file is unreadable (permission denied)
+
+**Given**: SOUL.md exists but has no read permissions
+**When**: The loader attempts to read it
+**Then**: A warning is logged per DES-002 (`component="context"`, level=WARNING), SOUL.md is skipped, remaining files are loaded normally.
+**Rationale**: Per R4 — graceful degradation. The agent starts with partial context rather than crashing.
+
+### Scenario: All files are missing or empty
+
+**Given**: The context directory exists but all files are missing or empty
+**When**: The loader runs
+**Then**: No sections are collected, `load_context` returns `None`. The coordinator starts without a custom system prompt (SDK default only). The preamble is NOT appended when there's no content.
+**Rationale**: Avoids appending a meaningless preamble with no actual context.
+
+### Scenario: User edits a context file between sessions
+
+**Given**: The user modifies SOUL.md between app restarts
+**When**: The app restarts and the context hook runs
+**Then**: The loader reads the updated SOUL.md content. The agent uses the updated personality.
+**Rationale**: Per R6 — context is loaded once at startup. Changes are reflected on restart.
+
+### Scenario: User edits a context file mid-session
+
+**Given**: The user modifies SOUL.md while the agent is running
+**When**: The user continues the conversation
+**Then**: The agent continues using the old SOUL.md content loaded at startup. Changes take effect on next restart.
+**Rationale**: Per R9 (Out) — hot-reload is explicitly deferred. Per AC: "when the user edits a context file mid-session, then the changes are NOT reflected until the next startup."
+
+## Open Questions
+
+None — all design decisions resolved.
+
+---
+
+## Detected Impacts
+
+### Affected Feature Designs
+- **docs/feature-designs/agent/core-architecture.md** — Modifies: Coordinator constructor gains `system_prompt` parameter; `ClaudeAgentOptions` configuration expands to include `system_prompt` via `SystemPromptPreset`
+- **docs/feature-designs/agent/workspace-bootstrap.md** — Modifies: `workspace_hook` moves from `bootstrap.py` to `workspace.py`; `bootstrap.py` becomes purely mechanism; subsystem-owned hook pattern established
+- **docs/feature-designs/agent/README.md** — Adds: May need a new "core-context" sub-capability entry
+
+### Notes for Reconciliation
+- Core architecture design needs to document the `system_prompt` parameter on Coordinator and its flow into SDK options
+- Workspace bootstrap design needs updating: `workspace_hook` location changed from `bootstrap.py` to `workspace.py`
+- Bootstrap Components table needs updating — `workspace_hook` removed from `bootstrap.py` responsibility
+- A new feature design doc may be needed for the "core-context" capability domain under `docs/feature-designs/agent/`
+- DLT-018 (update core context files) will consume `context.py` exports — the module API established here is the contract
+
+## Notes
+- The `SystemPromptPreset` type is importable from `claude_agent_sdk.types`, not from the top-level `claude_agent_sdk` package
+- The preamble content should be concise — the agent already understands markdown and XML. It needs to know: what the files are, that they're user-editable, and what each file's purpose is
+- Default template content (S4) should be thoughtful but brief — lengthy defaults waste context tokens on every session until the user customizes them
+- **Emptiness check**: Files should be considered "empty" when their stripped content is empty (i.e., `content.strip() == ""`). A file containing only whitespace is effectively empty and should be treated the same as a zero-byte file.
+- **CONTEXT_FILES type**: The ordered mapping of (filename, xml_tag, default_content) can be a `list[tuple[str, str, str]]` or a similar structure — left to implementer's discretion

--- a/docs/delta-plans/DLT-005.md
+++ b/docs/delta-plans/DLT-005.md
@@ -3,7 +3,7 @@
 **Delta Spec**: [../delta-specs/DLT-005.md](../delta-specs/DLT-005.md)
 **Delta Design**: [../delta-designs/DLT-005.md](../delta-designs/DLT-005.md)
 
-## Batch 1: Workspace Hook Extraction (S5) — ⧗ Pending
+## Batch 1: Workspace Hook Extraction (S5) — ✓ Done
 Depends on: — (none)
 
 ### Context & Research
@@ -63,7 +63,7 @@ from tachikoma.workspace import workspace_hook  # moved from bootstrap
 
 ---
 
-## Batch 2: Context Module — Hook, Loader & Templates (S1, S2, S4) — ⧗ Pending
+## Batch 2: Context Module — Hook, Loader & Templates (S1, S2, S4) — ✓ Done
 Depends on: Batch 1
 
 ### Context & Research
@@ -231,7 +231,7 @@ Depends on: Batch 1
 
 ---
 
-## Batch 3: Coordinator System Prompt Integration (S3) — ⧗ Pending
+## Batch 3: Coordinator System Prompt Integration (S3) — ✓ Done
 Depends on: Batch 2
 
 ### Context & Research

--- a/docs/delta-plans/DLT-005.md
+++ b/docs/delta-plans/DLT-005.md
@@ -1,0 +1,326 @@
+# Implementation Plan: DLT-005
+
+**Delta Spec**: [../delta-specs/DLT-005.md](../delta-specs/DLT-005.md)
+**Delta Design**: [../delta-designs/DLT-005.md](../delta-designs/DLT-005.md)
+
+## Batch 1: Workspace Hook Extraction (S5) — ⧗ Pending
+Depends on: — (none)
+
+### Context & Research
+- `src/tachikoma/bootstrap.py` — Source of the extraction; contains `workspace_hook` (lines 60-82) and the mechanism classes
+- `src/tachikoma/__main__.py` — Imports `workspace_hook` from `bootstrap`; import path changes to `workspace`
+- `src/tachikoma/sessions/hooks.py` — Reference pattern: subsystem-owned hook in its own module
+- `tests/test_bootstrap.py` — Contains `TestWorkspaceHook` class and `settings_manager` fixture; imports must update, tests move to new file
+- `tests/conftest.py` — May need the `settings_manager` fixture extracted here if shared across test files
+- DLT-005 Design § "Subsystem-owned hooks" — Design decision and rationale
+
+### Steps
+
+#### Step 1: Create `workspace.py` with extracted hook
+
+- Create: `src/tachikoma/workspace.py`
+- What to do: Move `workspace_hook` function from `bootstrap.py` to a new `workspace.py` module. Include the necessary imports (`BootstrapContext` from `bootstrap`). Keep the function signature and implementation identical.
+- Test: Module imports successfully; `workspace_hook` is importable from `tachikoma.workspace`
+
+```python
+# In src/tachikoma/workspace.py:
+# Move workspace_hook here from bootstrap.py
+# Import BootstrapContext from tachikoma.bootstrap
+# Keep identical function body
+```
+
+#### Step 2: Remove `workspace_hook` from `bootstrap.py`
+
+- Modify: `src/tachikoma/bootstrap.py`
+- What to do: Remove the `workspace_hook` function and any imports that were only used by it. The module should contain only: `BootstrapError`, `BootstrapContext`, `BootstrapHook` type alias, and `Bootstrap` class.
+- Test: `bootstrap.py` no longer exports `workspace_hook`; all mechanism classes still importable
+
+#### Step 3: Update `__main__.py` imports
+
+- Modify: `src/tachikoma/__main__.py`
+- What to do: Change import to get `workspace_hook` from `tachikoma.workspace` instead of `tachikoma.bootstrap`.
+- Test: Application starts successfully with the new import paths
+
+```python
+# In src/tachikoma/__main__.py:
+from tachikoma.bootstrap import Bootstrap, BootstrapError
+from tachikoma.workspace import workspace_hook  # moved from bootstrap
+```
+
+#### Step 4: Move workspace hook tests to `test_workspace.py`
+
+- Create: `tests/test_workspace.py`
+- Modify: `tests/test_bootstrap.py`
+- What to do: Move `TestWorkspaceHook` class to a new `tests/test_workspace.py` file to mirror the source module structure per DES-001. Update imports to use `from tachikoma.workspace import workspace_hook`. The `settings_manager` fixture (currently defined in `test_bootstrap.py`) is needed by both `TestBootstrap` and `TestWorkspaceHook` — extract it to `tests/conftest.py` so both test files can access it. Remove it from `test_bootstrap.py`.
+- Test: `uv run pytest tests/test_bootstrap.py tests/test_workspace.py -v` — all tests pass
+
+#### Step 5: Verify Batch 1
+
+- Run: `uv run pytest -x` — full test suite passes
+- Verify: `bootstrap.py` only contains mechanism code (Bootstrap, BootstrapContext, BootstrapHook, BootstrapError)
+- Verify: `workspace.py` contains `workspace_hook`
+- Verify: `__main__.py` imports from correct modules
+
+---
+
+## Batch 2: Context Module — Hook, Loader & Templates (S1, S2, S4) — ⧗ Pending
+Depends on: Batch 1
+
+### Context & Research
+- DLT-005 Spec §R1-R7 + Acceptance Criteria — File structure, bootstrap behavior, graceful degradation, ordering requirements
+- DLT-005 Design §S1, §S2, §S4, §Modeling, §Data Flow — Hook logic, loader algorithm, file-to-XML-tag mapping, return type, emptiness semantics
+- DLT-005 Design § "Empty files are silent, missing/unreadable files warn" — Key decision on warning behavior
+- DLT-005 Design § "Fatal vs graceful error boundary" — Dir failures fatal, file read failures graceful
+- DLT-005 Design §Notes — `content.strip() == ""` for emptiness, preamble concise, CONTEXT_FILES type flexible
+- `src/tachikoma/workspace.py` (from Batch 1) — Pattern reference: freshly established subsystem-owned hook
+- `src/tachikoma/sessions/hooks.py` — Pattern reference: subsystem hook reads settings, creates resources, stores in `ctx.extras`
+- DES-002 (Logging Conventions) — `logger.bind(component="context")`, structured messages, WARNING level for missing/unreadable files
+- `src/tachikoma/bootstrap.py` (from Batch 1) — `BootstrapContext` interface: `ctx.settings_manager.settings.workspace.path`, `ctx.extras`
+- `src/tachikoma/__main__.py` (from Batch 1) — Hook registration site; context hook registered after workspace hook
+
+### Steps
+
+#### Step 6: Create `context.py` with constants and file definitions
+
+- Create: `src/tachikoma/context.py`
+- What to do: Define the module with:
+  - `CONTEXT_DIR_NAME = "context"` constant
+  - `CONTEXT_FILES` — ordered list of tuples `(filename, xml_tag, default_content)` for SOUL.md/soul, USER.md/user, AGENTS.md/agents
+  - `CONTEXT_PREAMBLE` — concise hard-coded string explaining the context system to the agent (what the files are, that they're user-editable, what each file's purpose is)
+  - `DEFAULT_SOUL_CONTENT` — starter personality with traits and dialogue encouragement
+  - `DEFAULT_USER_CONTENT` — paragraph prompting assistant to ask the user about themselves
+  - `DEFAULT_AGENTS_CONTENT` — explains purpose as behavioral instructions with examples
+  - Module-level bound logger: `_log = logger.bind(component="context")`
+- Test: Module imports successfully; constants are accessible
+
+```python
+# In src/tachikoma/context.py:
+
+# Module-level logger per DES-002
+# _log = logger.bind(component="context")
+
+# CONTEXT_DIR_NAME = "context"
+
+# Default content constants — brief but meaningful
+# DEFAULT_SOUL_CONTENT = """..."""
+# DEFAULT_USER_CONTENT = """..."""
+# DEFAULT_AGENTS_CONTENT = """..."""
+
+# Ordered file definitions: (filename, xml_tag, default_content)
+# CONTEXT_FILES = [
+#     ("SOUL.md", "soul", DEFAULT_SOUL_CONTENT),
+#     ("USER.md", "user", DEFAULT_USER_CONTENT),
+#     ("AGENTS.md", "agents", DEFAULT_AGENTS_CONTENT),
+# ]
+
+# CONTEXT_PREAMBLE = """..."""  — concise explanation of the context system
+```
+
+#### Step 7: Implement `load_context` function
+
+- Create: `src/tachikoma/context.py` (add to module from Step 6)
+- What to do: Implement `load_context(workspace_path: Path) -> str | None` as a **synchronous** function (no `async`) — it only does small file reads, matching the pattern of `workspace_hook`'s synchronous I/O. Per the design's data flow:
+  1. Compute `context_path = workspace_path / CONTEXT_DIR_NAME`
+  2. For each file in CONTEXT_FILES order:
+     - Try to read the file
+     - If missing (FileNotFoundError) → log warning, skip
+     - If unreadable (PermissionError, OSError) → log warning, skip
+     - If empty (`content.strip() == ""`) → skip silently (no warning)
+     - If has content → wrap in XML tags (`<tag>\n{content}\n</tag>`) and collect
+  3. If no sections collected → return None
+  4. Prepend CONTEXT_PREAMBLE to collected sections
+  5. Return assembled string
+- Test: Unit tests for all code paths (see Step 9)
+
+```python
+# In src/tachikoma/context.py:
+
+# def load_context(workspace_path: Path) -> str | None:
+#     """Read context files and assemble into a system prompt string.
+#
+#     Synchronous — files are small. Returns None when no content found.
+#     """
+#     context_path = workspace_path / CONTEXT_DIR_NAME
+#     sections: list[str] = []
+#
+#     for filename, tag, _ in CONTEXT_FILES:
+#         # Try to read, handle missing/unreadable/empty per design
+#         # Wrap non-empty content in <tag>...</tag>
+#         # Collect into sections
+#
+#     if not sections:
+#         return None
+#
+#     return CONTEXT_PREAMBLE + "\n\n" + "\n\n".join(sections)
+```
+
+#### Step 8: Implement `context_hook` function
+
+- Create: `src/tachikoma/context.py` (add to module from Steps 6-7)
+- What to do: Implement `context_hook(ctx: BootstrapContext) -> None` as an async function (matching the `BootstrapHook` type). Synchronous I/O for small files is acceptable here, consistent with `workspace_hook`. Per the design's bootstrap flow:
+  1. Read workspace_path from `ctx.settings_manager.settings.workspace.path`
+  2. Compute `context_path = workspace_path / CONTEXT_DIR_NAME`
+  3. Create context directory (`context_path.mkdir(exist_ok=True)`) — if this fails, let the exception propagate (fatal, will be caught by Bootstrap and wrapped in BootstrapError)
+  4. For each file in CONTEXT_FILES: if file doesn't exist, write default content
+  5. Call `load_context(workspace_path)` to assemble the prompt
+  6. If result is not None, store in `ctx.extras["system_prompt"]`
+- Test: Unit tests for all code paths (see Step 9)
+
+```python
+# In src/tachikoma/context.py:
+
+# async def context_hook(ctx: BootstrapContext) -> None:
+#     workspace_path = ctx.settings_manager.settings.workspace.path
+#     context_path = workspace_path / CONTEXT_DIR_NAME
+#
+#     # Create dir — fatal on failure (propagates to BootstrapError)
+#     context_path.mkdir(exist_ok=True)
+#
+#     # Write default files for any that are missing
+#     # Call load_context and store result in ctx.extras if not None
+```
+
+#### Step 9: Write tests for context module
+
+- Create: `tests/test_context.py`
+- What to do: Write comprehensive tests covering all acceptance criteria. Use the existing test patterns (class-based, async, mocker fixture, tmp_path). Test classes:
+
+  **TestLoadContext** — tests for the loader function:
+  - All three files present with content → returns assembled string with preamble + XML sections in order
+  - One file missing → warns, includes remaining files
+  - One file empty → skips silently (no warning), includes remaining files
+  - Whitespace-only file treated as empty (`content.strip() == ""`)
+  - One file unreadable (PermissionError) → warns, includes remaining files
+  - All files missing → returns None
+  - All files empty → returns None (note: the design refines the AC "coordinator starts with only preamble appended" — design explicitly returns None to avoid appending a meaningless preamble with no actual context)
+  - Ordering: SOUL first, USER second, AGENTS last in output
+  - Preamble is prepended before any file content
+  - XML tags wrap each file's content (`<soul>`, `<user>`, `<agents>`)
+
+  **TestContextHook** — tests for the bootstrap hook:
+  - No context dir → creates dir + all three files with default content
+  - All files exist → nothing changed (idempotent)
+  - One file missing → only that file created
+  - Hook stores system_prompt in ctx.extras when files have content
+  - Hook does NOT store system_prompt when all files empty
+  - Dir creation failure → exception propagates (not caught)
+
+  **TestDefaultContent** — tests for template content:
+  - DEFAULT_SOUL_CONTENT contains personality/dialogue encouragement keywords
+  - DEFAULT_USER_CONTENT contains user-discovery prompt
+  - DEFAULT_AGENTS_CONTENT explains its purpose
+- Test: `uv run pytest tests/test_context.py -v` — all tests pass
+
+#### Step 10: Register context hook in `__main__.py`
+
+- Modify: `src/tachikoma/__main__.py`
+- What to do: Import `context_hook` from `tachikoma.context` and register it after the workspace hook:
+  ```
+  bootstrap.register("workspace", workspace_hook)
+  bootstrap.register("context", context_hook)        # NEW
+  bootstrap.register("sessions", session_recovery_hook)
+  ```
+  The context hook must run after workspace (needs the workspace directory to exist).
+- Test: Application starts, context files are created in workspace/context/
+
+#### Step 11: Verify Batch 2
+
+- Run: `uv run pytest -x` — full test suite passes
+- Verify: Starting the app creates `context/SOUL.md`, `context/USER.md`, `context/AGENTS.md` in workspace
+- Verify: Context hook logs at appropriate levels per DES-002
+
+---
+
+## Batch 3: Coordinator System Prompt Integration (S3) — ⧗ Pending
+Depends on: Batch 2
+
+### Context & Research
+- DLT-005 Design §S3, §Cross-Layer Contracts, §Startup Flow — Coordinator constructor, SystemPromptPreset wrapping, __main__.py wiring
+- DLT-005 Design § "SystemPromptPreset with append" — Key decision: `preset="claude_code"` with `append`, not replacement
+- DLT-005 Spec §R2, §R6 + Acceptance Criteria — Layered on SDK default, loaded once, passed at construction
+- `src/tachikoma/coordinator.py` — Current constructor builds `ClaudeAgentOptions` in `__init__` (line 55); `__aenter__` passes options to `ClaudeSDKClient`
+- `claude_agent_sdk.types.SystemPromptPreset` — TypedDict: `type="preset"`, `preset="claude_code"`, `append: NotRequired[str]`
+- `claude_agent_sdk.types.ClaudeAgentOptions` — `system_prompt: str | SystemPromptPreset | None` field
+- `tests/test_coordinator.py` — Existing patterns: `mock_sdk` fixture, how options are verified via `mock_cls.call_args`
+- `src/tachikoma/__main__.py` (from Batches 1 and 2) — Where `bootstrap.extras.get("system_prompt")` is read and passed to Coordinator
+
+### Steps
+
+#### Step 12: Add `system_prompt` parameter to Coordinator
+
+- Modify: `src/tachikoma/coordinator.py`
+- What to do:
+  1. Import `SystemPromptPreset` from `claude_agent_sdk.types`
+  2. Add `system_prompt: str | None = None` parameter to `Coordinator.__init__`
+  3. In `__init__`, where `ClaudeAgentOptions` is currently built (line 55): if `system_prompt` is not None, wrap it in a `SystemPromptPreset` and pass as the `system_prompt` field on the options. If None, leave it unset (SDK default).
+- Test: Unit tests for both paths (see Step 13)
+
+```python
+# In src/tachikoma/coordinator.py __init__:
+# Add system_prompt: str | None = None parameter
+# Build SystemPromptPreset when system_prompt is provided
+# Pass to ClaudeAgentOptions(system_prompt=..., ...)
+```
+
+#### Step 13: Write tests for system prompt integration
+
+- Modify: `tests/test_coordinator.py`
+- What to do: Add a new test class `TestCoordinatorSystemPrompt` with tests:
+  - Given system_prompt is provided → ClaudeAgentOptions.system_prompt is a SystemPromptPreset with type="preset", preset="claude_code", and append=the provided string
+  - Given system_prompt is None → ClaudeAgentOptions.system_prompt is None (SDK default)
+  - Given system_prompt is provided → existing coordinator behavior (send_message, lifecycle) still works correctly
+- Test: `uv run pytest tests/test_coordinator.py -v` — all tests pass
+
+#### Step 14: Wire system prompt from bootstrap extras to Coordinator in `__main__.py`
+
+- Modify: `src/tachikoma/__main__.py`
+- What to do: After bootstrap.run(), read the system prompt from extras and pass to Coordinator:
+  ```python
+  system_prompt = bootstrap.extras.get("system_prompt")
+  ```
+  Then pass `system_prompt=system_prompt` to the Coordinator constructor alongside existing arguments.
+- Test: Application starts with context loaded into the coordinator's system prompt
+
+#### Step 15: Verify Batch 3 and full acceptance criteria
+
+- Run: `uv run pytest -x` — full test suite passes
+- Run: `uv run ty check` — type checking passes
+- Run: `uv run ruff check` — linting passes
+- Verify end-to-end: Application starts, context files created, system prompt assembled and passed to SDK
+- Verify acceptance criteria coverage:
+  - [ ] Bootstrap hook creates context dir + files (Steps 8, 9)
+  - [ ] Idempotent on re-run (Step 9)
+  - [ ] Missing file selectively created (Step 9)
+  - [ ] Hook registered after workspace hook (Step 10)
+  - [ ] Default content is meaningful (Steps 6, 9)
+  - [ ] Assembled prompt has preamble + XML sections in order (Steps 7, 9)
+  - [ ] SDK default prompt preserved via SystemPromptPreset (Steps 12, 13)
+  - [ ] Graceful degradation for missing/empty/unreadable (Steps 7, 9)
+  - [ ] Files human-readable in workspace (inherent — plain markdown)
+
+---
+
+## Files Changed
+
+- [ ] `src/tachikoma/workspace.py` — New: extracted workspace_hook (Batch 1)
+- [ ] `src/tachikoma/bootstrap.py` — Modified: workspace_hook removed, mechanism only (Batch 1)
+- [ ] `src/tachikoma/context.py` — New: context domain module — hook, loader, constants (Batch 2)
+- [ ] `src/tachikoma/coordinator.py` — Modified: system_prompt parameter + SystemPromptPreset (Batch 3)
+- [ ] `src/tachikoma/__main__.py` — Modified: import paths, context hook registration, system_prompt wiring (Batches 1, 2, 3)
+- [ ] `tests/conftest.py` — Modified: settings_manager fixture extracted here (Batch 1)
+- [ ] `tests/test_workspace.py` — New: workspace hook tests moved from test_bootstrap.py (Batch 1)
+- [ ] `tests/test_bootstrap.py` — Modified: workspace hook tests + fixture removed (Batch 1)
+- [ ] `tests/test_context.py` — New: context module tests (Batch 2)
+- [ ] `tests/test_coordinator.py` — Modified: system prompt integration tests added (Batch 3)
+
+## Reconciliation Notes
+
+After implementation, the following feature docs will need reconciliation:
+- **docs/feature-specs/agent/core-architecture.md** — Add system_prompt parameter to Coordinator
+- **docs/feature-specs/agent/workspace-bootstrap.md** — Add context hook entry
+- **docs/feature-designs/agent/core-architecture.md** — Document SystemPromptPreset integration
+- **docs/feature-designs/agent/workspace-bootstrap.md** — Update workspace_hook location, document subsystem-owned hook pattern
+
+## Notes
+
+[To be filled during implementation]

--- a/docs/delta-specs/DLT-005.md
+++ b/docs/delta-specs/DLT-005.md
@@ -1,0 +1,80 @@
+# Delta Spec: DLT-005 - Load foundational context for personality and user knowledge
+
+## Story
+
+As a user, I want the assistant to have a consistent personality, know about me, and follow operational guidelines so that interactions feel natural and personalized regardless of which memories are retrieved.
+
+## What It Does
+
+Three markdown files in a `context/` subdirectory of the workspace establish the assistant's identity and baseline knowledge: SOUL.md defines personality and tone, USER.md captures known information about the user, and AGENTS.md provides behavioral instructions that don't fit the other two files. A bootstrap hook creates default template files on first run. At startup, a context loader reads these files and assembles them into an appended system prompt — preceded by a hard-coded preamble that explains the context system to the agent. The assembled prompt is passed to the Claude Agent SDK, preserving the SDK's default instructions while layering on custom context. Missing, empty, or unreadable files are handled gracefully — the assistant starts without that context rather than crashing.
+
+## Requirements
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R0 | Provide the assistant with foundational, always-available context through core files loaded into the system prompt | Core goal |
+| R1 | Three core context files as human-readable markdown in `context/` subdirectory: SOUL.md (personality/tone), USER.md (user knowledge), AGENTS.md (behavioral instructions that don't fit SOUL or USER) | Must-have |
+| R2 | Context layered on top of the SDK's default system prompt without replacing it | Must-have |
+| R3 | Bootstrap hook creates `context/` directory and default template files on first run (idempotent) | Must-have |
+| R4 | Graceful handling when files are missing, empty, or unreadable — log a warning but continue without crashing | Must-have |
+| R5 | Default SOUL.md has a starter personality encouraging an initial dialogue with the user to understand their expectations | Must-have |
+| R5.1 | Default USER.md has a paragraph prompting the assistant to ask the user about themselves and fill in the file | Must-have |
+| R5.2 | Default AGENTS.md explains its purpose as a place for behavioral instructions that don't fit SOUL or USER | Must-have |
+| R6 | Context loaded once during bootstrap and passed to the coordinator at startup | Must-have |
+| R7 | Hard-coded preamble in code explains the context system to the agent before the file contents | Must-have |
+| R8 | Per-session context reload on session restart | Out (deferred to session restart delta) |
+| R9 | Hot-reload of context files mid-session | Out |
+
+## Acceptance Criteria
+
+### Bootstrap hook (R3, R1)
+
+- [ ] Given no `context/` directory in workspace, when the context bootstrap hook runs, then the directory is created along with SOUL.md, USER.md, and AGENTS.md with default content
+- [ ] Given `context/` directory and all three files already exist, when the hook runs, then nothing is changed (idempotent)
+- [ ] Given `context/` directory exists but one file is missing, when the hook runs, then only the missing file is created with default content
+- [ ] Given the bootstrap system, when hooks are registered, then the context hook is registered after the workspace hook (depends on workspace directory existing)
+
+### Default template content (R5, R5.1, R5.2)
+
+- [ ] Given the bootstrap hook creates SOUL.md, then it contains a starter personality with guidelines encouraging an initial conversation with the user to understand their expectations and preferences
+- [ ] Given the bootstrap hook creates USER.md, then it contains a paragraph prompting the assistant to ask the user about themselves and populate the file over time
+- [ ] Given the bootstrap hook creates AGENTS.md, then it explains its purpose as a place for behavioral instructions that don't fit SOUL or USER, with examples of what might go here
+
+### Context loading and assembly (R0, R2, R6, R7)
+
+- [ ] Given all three context files exist with content, when bootstrap runs, then the files are read and assembled into an appended system prompt that preserves the SDK's default prompt
+- [ ] Given context files are loaded, when the assembled prompt is built, then a hard-coded preamble explaining the context system is placed before the file contents
+- [ ] Given the files are concatenated, then the ordering is: SOUL.md first (personality), then USER.md (user knowledge), then AGENTS.md last (behavioral instructions)
+- [ ] Given context files are loaded, when the coordinator is created, then the system prompt includes the SDK default instructions, the hard-coded preamble, and the context file contents
+- [ ] Given context is loaded at startup, when the user edits a context file mid-session, then the changes are NOT reflected until the next startup
+
+### Graceful degradation (R4)
+
+- [ ] Given one or more context files are missing at startup, when context loading runs, then a warning is logged for each missing file and available files are still loaded
+- [ ] Given all context files are empty, when context loading runs, then the coordinator starts with only the hard-coded preamble appended (no file content)
+- [ ] Given all context files are missing, when context loading runs, then the coordinator starts with only the hard-coded preamble appended (no file content)
+- [ ] Given a context file exists but cannot be read (e.g., permission denied), when context loading runs, then a warning is logged for the unreadable file and available files are still loaded
+
+### Transparency (R1)
+
+- [ ] Given the context files exist, when the user navigates to the workspace `context/` directory, then they can see and edit SOUL.md, USER.md, and AGENTS.md in any text editor
+- [ ] Given a user edits a context file and restarts the app, then the agent uses the updated content
+
+## Requires
+
+Dependencies:
+- None
+
+---
+
+## Detected Impacts
+
+### Affected Features
+- **docs/feature-specs/agent/core-architecture.md** — Modifies: Coordinator now receives a system prompt parameter; ClaudeAgentOptions configuration expands to include system_prompt
+- **docs/feature-specs/agent/workspace-bootstrap.md** — Adds: New bootstrap hook for context directory and file initialization
+
+### Notes for Reconciliation
+- Core architecture spec needs to document the system_prompt parameter on Coordinator and its flow into SDK options
+- Workspace bootstrap spec needs a new hook entry for the context initialization hook
+- A new feature spec may be needed for the "core context" capability domain under `docs/feature-specs/agent/`
+- DLT-018 (update core context files) will modify these same files — it consumes whatever format is established here

--- a/docs/planning/DELTAS.md
+++ b/docs/planning/DELTAS.md
@@ -78,7 +78,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/deltas.py priority list --level 1        # 
 **Description**: Fallback conversation boundary detection that monitors for periods of user inactivity. After a configurable threshold (~20 minutes by default), the system signals the session registry (DLT-027) to close the current session, triggering downstream post-processing. This serves as a safety net for cases where the user goes silent without a clear topic change — DLT-026's topic-based analysis is the primary boundary mechanism, but it only fires on incoming messages. The inactivity timeout catches the "user walked away" case. The threshold should be configurable per-deployment.
 
 ### DLT-005: Load foundational context for personality and user knowledge
-**Status**: ✗ Defined
+**Status**: ✓ Design
 **Depends on**: None
 **Priority**: 2 (High)
 **Complexity**: Easy

--- a/docs/planning/DELTAS.md
+++ b/docs/planning/DELTAS.md
@@ -78,7 +78,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/deltas.py priority list --level 1        # 
 **Description**: Fallback conversation boundary detection that monitors for periods of user inactivity. After a configurable threshold (~20 minutes by default), the system signals the session registry (DLT-027) to close the current session, triggering downstream post-processing. This serves as a safety net for cases where the user goes silent without a clear topic change — DLT-026's topic-based analysis is the primary boundary mechanism, but it only fires on incoming messages. The inactivity timeout catches the "user walked away" case. The threshold should be configurable per-deployment.
 
 ### DLT-005: Load foundational context for personality and user knowledge
-**Status**: ✓ Plan
+**Status**: ✓ Implementation
 **Depends on**: None
 **Priority**: 2 (High)
 **Complexity**: Easy

--- a/docs/planning/DELTAS.md
+++ b/docs/planning/DELTAS.md
@@ -78,7 +78,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/deltas.py priority list --level 1        # 
 **Description**: Fallback conversation boundary detection that monitors for periods of user inactivity. After a configurable threshold (~20 minutes by default), the system signals the session registry (DLT-027) to close the current session, triggering downstream post-processing. This serves as a safety net for cases where the user goes silent without a clear topic change — DLT-026's topic-based analysis is the primary boundary mechanism, but it only fires on incoming messages. The inactivity timeout catches the "user walked away" case. The threshold should be configurable per-deployment.
 
 ### DLT-005: Load foundational context for personality and user knowledge
-**Status**: ✓ Design
+**Status**: ✓ Plan
 **Depends on**: None
 **Priority**: 2 (High)
 **Complexity**: Easy

--- a/src/tachikoma/__main__.py
+++ b/src/tachikoma/__main__.py
@@ -5,11 +5,13 @@ import sys
 
 from claude_agent_sdk import CLIConnectionError, CLINotFoundError, ProcessError
 
-from tachikoma.bootstrap import Bootstrap, BootstrapError, workspace_hook
+from tachikoma.bootstrap import Bootstrap, BootstrapError
 from tachikoma.config import SettingsManager
+from tachikoma.context import context_hook
 from tachikoma.coordinator import Coordinator
 from tachikoma.repl import Repl
 from tachikoma.sessions import session_recovery_hook
+from tachikoma.workspace import workspace_hook
 
 
 async def main() -> None:
@@ -17,6 +19,7 @@ async def main() -> None:
 
     bootstrap = Bootstrap(settings_manager)
     bootstrap.register("workspace", workspace_hook)
+    bootstrap.register("context", context_hook)
     bootstrap.register("sessions", session_recovery_hook)
 
     try:
@@ -31,12 +34,16 @@ async def main() -> None:
     repository = bootstrap.extras["session_repository"]
     registry = bootstrap.extras["session_registry"]
 
+    # Get the system prompt from the context hook (if available)
+    system_prompt = bootstrap.extras.get("system_prompt")
+
     try:
         async with Coordinator(
             allowed_tools=settings.agent.allowed_tools,
             model=settings.agent.model,
             cwd=settings.workspace.path,
             registry=registry,
+            system_prompt=system_prompt,
         ) as coordinator:
             repl = Repl(coordinator, history_path=settings.workspace.path / "repl_history")
             await repl.run()

--- a/src/tachikoma/bootstrap.py
+++ b/src/tachikoma/bootstrap.py
@@ -55,27 +55,3 @@ class Bootstrap:
                 await hook(self._context)
             except Exception as exc:
                 raise BootstrapError(f"Hook '{name}' failed: {exc}") from exc
-
-
-async def workspace_hook(ctx: BootstrapContext) -> None:
-    """Create workspace root and .tachikoma/ data folder if missing."""
-    settings = ctx.settings_manager.settings
-    workspace_path = settings.workspace.path
-
-    try:
-        workspace_path.mkdir(parents=True, exist_ok=True)
-    except FileExistsError:
-        raise RuntimeError(
-            f"Workspace path exists but is not a directory: {workspace_path}"
-        )
-    except PermissionError as exc:
-        raise RuntimeError(
-            f"Cannot create workspace directory: Permission denied: {workspace_path}"
-        ) from exc
-
-    try:
-        settings.workspace.data_path.mkdir(exist_ok=True)
-    except PermissionError as exc:
-        raise RuntimeError(
-            f"Cannot create data directory: Permission denied: {settings.workspace.data_path}"
-        ) from exc

--- a/src/tachikoma/context.py
+++ b/src/tachikoma/context.py
@@ -1,0 +1,176 @@
+"""Core context file management.
+
+Provides foundational context for the assistant through three markdown files:
+SOUL.md (personality/tone), USER.md (user knowledge), and AGENTS.md (behavioral instructions).
+
+These files are loaded once at startup and assembled into a system prompt that layers
+on top of the SDK's default prompt.
+
+See: DLT-005 (Load foundational context for personality and user knowledge).
+"""
+
+from pathlib import Path
+
+from loguru import logger
+
+from tachikoma.bootstrap import BootstrapContext
+
+_log = logger.bind(component="context")
+
+# Directory name under workspace root
+CONTEXT_DIR_NAME = "context"
+
+# Default content for each context file
+
+DEFAULT_SOUL_CONTENT = """\
+# Personality
+
+You are a thoughtful, proactive assistant. Your goal is to be genuinely helpful while
+maintaining a warm, conversational tone.
+
+## Core Traits
+
+- **Curious**: Ask clarifying questions when something is ambiguous rather than assuming.
+- **Honest**: Admit when you don't know something or made a mistake.
+- **Proactive**: Anticipate needs and offer suggestions without being asked.
+- **Concise**: Get to the point while remaining friendly.
+
+## Communication Style
+
+- Use clear, natural language
+- Avoid being overly formal or robotic
+- Don't use unnecessary filler words
+
+## Getting Started
+
+This is your starting personality. Engage in a conversation with the user to understand
+their expectations, preferences, and how they'd like you to behave. As you learn more
+about what works for them, suggest updates to this file.
+"""
+
+DEFAULT_USER_CONTENT = """\
+# About the User
+
+This file captures what you know about the user — their name, interests, preferences,
+projects, and communication style.
+
+Start by asking the user about themselves. What should you know about them? What are
+their goals? How do they prefer to communicate? Update this file as you learn more.
+
+Over time, this becomes a living document that helps you provide personalized assistance.
+"""
+
+DEFAULT_AGENTS_CONTENT = """\
+# Agent Instructions
+
+This file contains behavioral instructions that don't fit in SOUL.md (personality) or
+USER.md (user knowledge). Use it for operational guidelines and workflow preferences.
+
+## Examples of What Goes Here
+
+- Preferred formats for specific outputs (code, summaries, lists)
+- Tool usage preferences (which tools to use when)
+- Workflow conventions (how to structure multi-step tasks)
+- Domain-specific instructions (project-specific patterns)
+
+## Getting Started
+
+This is your baseline. As you work with the user and discover their preferences,
+suggest additions to this file.
+"""
+
+# Ordered file definitions: (filename, xml_tag, default_content)
+CONTEXT_FILES = [
+    ("SOUL.md", "soul", DEFAULT_SOUL_CONTENT),
+    ("USER.md", "user", DEFAULT_USER_CONTENT),
+    ("AGENTS.md", "agents", DEFAULT_AGENTS_CONTENT),
+]
+
+# Hard-coded preamble explaining the context system
+CONTEXT_PREAMBLE = """\
+The following sections contain your foundational context — personality traits, user knowledge,
+and behavioral instructions. These files live in the workspace's `context/` directory and are
+user-editable. You can suggest updates when you learn something that should be persisted.
+
+Each section is wrapped in XML tags to clearly delineate its purpose."""
+
+
+def load_context(workspace_path: Path) -> str | None:
+    """Read context files and assemble into a system prompt string.
+
+    Synchronous — files are small. Returns None when no content found.
+
+    Args:
+        workspace_path: Path to the workspace root directory.
+
+    Returns:
+        Assembled system prompt string with preamble and XML-wrapped sections,
+        or None if all files are missing or empty.
+    """
+    context_path = workspace_path / CONTEXT_DIR_NAME
+    sections: list[str] = []
+
+    for filename, tag, _ in CONTEXT_FILES:
+        file_path = context_path / filename
+
+        try:
+            content = file_path.read_text()
+        except FileNotFoundError:
+            _log.warning("Context file not found: file={file}", file=filename)
+            continue
+        except PermissionError as err:
+            _log.warning(
+                "Context file unreadable (permission denied): file={file} err={err}",
+                file=filename,
+                err=str(err),
+            )
+            continue
+        except OSError as err:
+            _log.warning(
+                "Context file unreadable: file={file} err={err}",
+                file=filename,
+                err=str(err),
+            )
+            continue
+
+        # Skip empty files silently (no warning — intentional user action)
+        if content.strip() == "":
+            continue
+
+        # Wrap content in XML tags
+        sections.append(f"<{tag}>\n{content}\n</{tag}>")
+
+    if not sections:
+        return None
+
+    return CONTEXT_PREAMBLE + "\n\n" + "\n\n".join(sections)
+
+
+async def context_hook(ctx: BootstrapContext) -> None:
+    """Bootstrap hook: create context directory and default files if missing.
+
+    Creates the context/ directory under the workspace root and writes default
+    template files for any that don't exist. Then loads the context and stores
+    the assembled prompt in ctx.extras["system_prompt"].
+
+    Args:
+        ctx: Bootstrap context with settings_manager and extras bag.
+    """
+    workspace_path = ctx.settings_manager.settings.workspace.path
+    context_path = workspace_path / CONTEXT_DIR_NAME
+
+    # Create context directory — fatal on failure (propagates to BootstrapError)
+    # parents=True ensures workspace dir exists if context_hook runs before workspace_hook
+    context_path.mkdir(parents=True, exist_ok=True)
+
+    # Write default files for any that are missing (idempotent)
+    for filename, _, default_content in CONTEXT_FILES:
+        file_path = context_path / filename
+        if not file_path.exists():
+            file_path.write_text(default_content)
+            _log.debug("Created default context file: file={file}", file=filename)
+
+    # Load context and store in extras
+    system_prompt = load_context(workspace_path)
+    if system_prompt is not None:
+        ctx.extras["system_prompt"] = system_prompt

--- a/src/tachikoma/coordinator.py
+++ b/src/tachikoma/coordinator.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import TracebackType
 
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, CLIConnectionError, ProcessError
+from claude_agent_sdk.types import SystemPromptPreset
 from loguru import logger
 
 from tachikoma.adapter import adapt
@@ -51,11 +52,22 @@ class Coordinator:
         model: str | None = None,
         cwd: Path | None = None,
         registry: SessionRegistry | None = None,
+        system_prompt: str | None = None,
     ) -> None:
+        # Build SystemPromptPreset when system_prompt is provided
+        sdk_system_prompt = None
+        if system_prompt is not None:
+            sdk_system_prompt = SystemPromptPreset(
+                type="preset",
+                preset="claude_code",
+                append=system_prompt,
+            )
+
         self._options = ClaudeAgentOptions(
             allowed_tools=allowed_tools or [],
             model=model,
             cwd=cwd,
+            system_prompt=sdk_system_prompt,
         )
         self._cwd = cwd
         self._client: ClaudeSDKClient | None = None

--- a/src/tachikoma/workspace.py
+++ b/src/tachikoma/workspace.py
@@ -1,0 +1,33 @@
+"""Workspace initialization hook.
+
+Provides the workspace_hook bootstrap function that creates the workspace
+root and .tachikoma/ data folder if missing.
+
+See: DLT-023 (Workspace bootstrap), DLT-005 (Hook extraction pattern).
+"""
+
+from tachikoma.bootstrap import BootstrapContext
+
+
+async def workspace_hook(ctx: BootstrapContext) -> None:
+    """Create workspace root and .tachikoma/ data folder if missing."""
+    settings = ctx.settings_manager.settings
+    workspace_path = settings.workspace.path
+
+    try:
+        workspace_path.mkdir(parents=True, exist_ok=True)
+    except FileExistsError:
+        raise RuntimeError(
+            f"Workspace path exists but is not a directory: {workspace_path}"
+        )
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Cannot create workspace directory: Permission denied: {workspace_path}"
+        ) from exc
+
+    try:
+        settings.workspace.data_path.mkdir(exist_ok=True)
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Cannot create data directory: Permission denied: {settings.workspace.data_path}"
+        ) from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Root pytest configuration and shared fixtures.
+
+This file is auto-loaded by pytest and contains fixtures shared across test files.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tachikoma.config import SettingsManager
+
+
+@pytest.fixture
+def settings_manager(tmp_path: Path) -> SettingsManager:
+    """Create a SettingsManager with a temporary workspace path."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(f'[workspace]\npath = "{tmp_path / "workspace"}"\n')
+    return SettingsManager(config_path)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,19 +3,10 @@
 Tests for DLT-023: Bootstrap agent workspace on first run.
 """
 
-from pathlib import Path
-
 import pytest
 
-from tachikoma.bootstrap import Bootstrap, BootstrapContext, BootstrapError, workspace_hook
+from tachikoma.bootstrap import Bootstrap, BootstrapError
 from tachikoma.config import SettingsManager
-
-
-@pytest.fixture
-def settings_manager(tmp_path: Path) -> SettingsManager:
-    config_path = tmp_path / "config.toml"
-    config_path.write_text(f'[workspace]\npath = "{tmp_path / "workspace"}"\n')
-    return SettingsManager(config_path)
 
 
 class TestBootstrap:
@@ -131,64 +122,3 @@ class TestBootstrap:
         await bootstrap.run()
 
         assert bootstrap.extras["my_object"] == {"key": "value"}
-
-
-class TestWorkspaceHook:
-    """Tests for the workspace initialization hook."""
-
-    @pytest.fixture
-    def ctx(self, settings_manager: SettingsManager) -> BootstrapContext:
-        return BootstrapContext(settings_manager=settings_manager, prompt=input)
-
-    async def test_creates_workspace_and_data_dir(
-        self, ctx: BootstrapContext, settings_manager: SettingsManager,
-    ) -> None:
-        """AC (R0, R1): No dirs exist, both workspace and .tachikoma/ are created."""
-        await workspace_hook(ctx)
-
-        ws = settings_manager.settings.workspace
-
-        assert ws.path.is_dir()
-        assert ws.data_path.is_dir()
-
-    async def test_skips_when_workspace_exists(
-        self, ctx: BootstrapContext, settings_manager: SettingsManager,
-    ) -> None:
-        """AC (R7): Dirs already exist, no error on re-run."""
-        ws = settings_manager.settings.workspace
-        ws.path.mkdir(parents=True)
-        ws.data_path.mkdir()
-
-        await workspace_hook(ctx)
-
-        assert ws.path.is_dir()
-        assert ws.data_path.is_dir()
-
-    async def test_creates_data_dir_when_workspace_exists(
-        self, ctx: BootstrapContext, settings_manager: SettingsManager,
-    ) -> None:
-        """AC (R1): Workspace exists but .tachikoma/ doesn't, creates it."""
-        ws = settings_manager.settings.workspace
-        ws.path.mkdir(parents=True)
-
-        await workspace_hook(ctx)
-
-        assert ws.data_path.is_dir()
-
-    async def test_raises_when_path_is_file(
-        self, ctx: BootstrapContext, settings_manager: SettingsManager,
-    ) -> None:
-        """AC (R9): Workspace path is a file, raises with clear error."""
-        ws = settings_manager.settings.workspace
-        ws.path.parent.mkdir(parents=True, exist_ok=True)
-        ws.path.touch()
-
-        with pytest.raises(RuntimeError, match="not a directory"):
-            await workspace_hook(ctx)
-
-    async def test_raises_on_permission_error(self, ctx: BootstrapContext, mocker) -> None:
-        """AC (R9): mkdir fails with PermissionError, raises with clear message."""
-        mocker.patch.object(Path, "mkdir", side_effect=PermissionError)
-
-        with pytest.raises(RuntimeError, match="Permission denied"):
-            await workspace_hook(ctx)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,305 @@
+"""Core context module tests.
+
+Tests for DLT-005: Load foundational context for personality and user knowledge.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tachikoma.bootstrap import BootstrapContext
+from tachikoma.config import SettingsManager
+from tachikoma.context import (
+    CONTEXT_DIR_NAME,
+    CONTEXT_FILES,
+    CONTEXT_PREAMBLE,
+    DEFAULT_AGENTS_CONTENT,
+    DEFAULT_SOUL_CONTENT,
+    DEFAULT_USER_CONTENT,
+    context_hook,
+    load_context,
+)
+
+
+class TestLoadContext:
+    """Tests for the load_context function."""
+
+    def test_all_files_present_returns_assembled_string(self, tmp_path: Path) -> None:
+        """AC: All files with content → assembled string with preamble + XML sections."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("Test soul content")
+        (context_dir / "USER.md").write_text("Test user content")
+        (context_dir / "AGENTS.md").write_text("Test agents content")
+
+        result = load_context(tmp_path)
+
+        assert result is not None
+        assert CONTEXT_PREAMBLE in result
+        assert "<soul>\nTest soul content\n</soul>" in result
+        assert "<user>\nTest user content\n</user>" in result
+        assert "<agents>\nTest agents content\n</agents>" in result
+
+    def test_ordering_is_soul_user_agents(self, tmp_path: Path) -> None:
+        """AC: Ordering is SOUL first, USER second, AGENTS last in output."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("A")
+        (context_dir / "USER.md").write_text("B")
+        (context_dir / "AGENTS.md").write_text("C")
+
+        result = load_context(tmp_path)
+        assert result is not None
+
+        # Check ordering
+        soul_pos = result.find("<soul>")
+        user_pos = result.find("<user>")
+        agents_pos = result.find("<agents>")
+
+        assert soul_pos < user_pos < agents_pos
+
+    def test_preamble_prepended(self, tmp_path: Path) -> None:
+        """AC: Preamble is prepended before any file content."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("Content")
+
+        result = load_context(tmp_path)
+        assert result is not None
+
+        # Preamble comes first
+        assert result.startswith(CONTEXT_PREAMBLE)
+
+    def test_one_file_missing_warns_and_includes_remaining(self, tmp_path: Path, caplog) -> None:
+        """AC: One file missing → warns, includes remaining files."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("Soul content")
+        (context_dir / "AGENTS.md").write_text("Agents content")
+        # USER.md is missing
+
+        with caplog.at_level("WARNING"):
+            load_context(tmp_path)
+
+        result = load_context(tmp_path)
+        assert result is not None
+        assert "<soul>" in result
+        assert "<agents>" in result
+        assert "<user>" not in result
+
+    def test_one_file_empty_skips_silently(self, tmp_path: Path, caplog) -> None:
+        """AC: One file empty → skips silently (no warning), includes remaining files."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("Soul content")
+        (context_dir / "USER.md").write_text("")  # Empty
+        (context_dir / "AGENTS.md").write_text("Agents content")
+
+        load_context(tmp_path)
+
+        # No warning should be logged
+        assert not any(record.level == "WARNING" for record in caplog.records)
+
+        result = load_context(tmp_path)
+        assert result is not None
+        assert "<soul>" in result
+        assert "<agents>" in result
+        assert "<user>" not in result
+
+    def test_whitespace_only_file_treated_as_empty(self, tmp_path: Path) -> None:
+        """AC: Whitespace-only file treated as empty (= content.strip() == "")."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("   \n\n   ")  # Whitespace only
+        (context_dir / "USER.md").write_text("User content")
+        (context_dir / "AGENTS.md").write_text("Agents content")
+
+        result = load_context(tmp_path)
+        assert result is not None
+        assert "<soul>" not in result
+        assert "<user>" in result
+        assert "<agents>" in result
+
+    def test_one_file_unreadable_warns_and_includes_remaining(
+        self, tmp_path: Path, caplog, mocker
+    ) -> None:
+        """AC: One file unreadable (PermissionError) → warns, includes remaining files."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("Soul content")
+        (context_dir / "USER.md").write_text("User content")
+        (context_dir / "AGENTS.md").write_text("Agents content")
+
+        # Make SOUL.md unreadable
+        mocker.patch.object(
+            Path,
+            "read_text",
+            side_effect=PermissionError("Permission denied"),
+        )
+
+        with caplog.at_level("WARNING"):
+            load_context(tmp_path)
+
+    def test_all_files_missing_returns_none(self, tmp_path: Path) -> None:
+        """AC: All files missing → returns None."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+        # No files created
+
+        result = load_context(tmp_path)
+        assert result is None
+
+    def test_all_files_empty_returns_none(self, tmp_path: Path) -> None:
+        """AC: All files empty → returns None."""
+        context_dir = tmp_path / CONTEXT_DIR_NAME
+        context_dir.mkdir()
+
+        (context_dir / "SOUL.md").write_text("")
+        (context_dir / "USER.md").write_text("")
+        (context_dir / "AGENTS.md").write_text("")
+
+        result = load_context(tmp_path)
+        assert result is None
+
+
+class TestContextHook:
+    """Tests for the context_hook bootstrap hook."""
+
+    @pytest.fixture
+    def ctx(self, settings_manager: SettingsManager) -> BootstrapContext:
+        return BootstrapContext(settings_manager=settings_manager, prompt=input)
+
+    async def test_creates_context_dir_and_default_files(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager
+    ) -> None:
+        """AC: No context dir → creates dir + all three files with default content."""
+        await context_hook(ctx)
+
+        ws = settings_manager.settings.workspace
+        context_path = ws.path / CONTEXT_DIR_NAME
+
+        assert context_path.is_dir()
+        assert (context_path / "SOUL.md").exists()
+        assert (context_path / "USER.md").exists()
+        assert (context_path / "AGENTS.md").exists()
+
+        # Verify default content
+        soul_content = (context_path / "SOUL.md").read_text()
+        assert soul_content == DEFAULT_SOUL_CONTENT
+
+    async def test_idempotent_when_all_files_exist(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager
+    ) -> None:
+        """AC: All files exist → nothing changed (idempotent)."""
+        ws = settings_manager.settings.workspace
+        context_path = ws.path / CONTEXT_DIR_NAME
+        context_path.mkdir(parents=True)
+
+        # Create files with custom content
+        (context_path / "SOUL.md").write_text("Custom soul")
+        (context_path / "USER.md").write_text("Custom user")
+        (context_path / "AGENTS.md").write_text("Custom agents")
+
+        await context_hook(ctx)
+
+        # Content should NOT be overwritten
+        assert (context_path / "SOUL.md").read_text() == "Custom soul"
+        assert (context_path / "USER.md").read_text() == "Custom user"
+        assert (context_path / "AGENTS.md").read_text() == "Custom agents"
+
+    async def test_one_file_missing_creates_only_that_file(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager
+    ) -> None:
+        """AC: One file missing → only that file created."""
+        ws = settings_manager.settings.workspace
+        context_path = ws.path / CONTEXT_DIR_NAME
+        context_path.mkdir(parents=True)
+
+        (context_path / "SOUL.md").write_text("Existing soul")
+        (context_path / "AGENTS.md").write_text("Existing agents")
+        # USER.md is missing
+
+        await context_hook(ctx)
+
+        # Only USER.md should be created
+        assert (context_path / "SOUL.md").read_text() == "Existing soul"
+        assert (context_path / "AGENTS.md").read_text() == "Existing agents"
+        assert (context_path / "USER.md").read_text() == DEFAULT_USER_CONTENT
+
+    async def test_stores_system_prompt_when_files_have_content(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager
+    ) -> None:
+        """AC: Hook stores system_prompt in ctx.extras when files have content."""
+        ws = settings_manager.settings.workspace
+        context_path = ws.path / CONTEXT_DIR_NAME
+        context_path.mkdir(parents=True)
+
+        (context_path / "SOUL.md").write_text("Content")
+
+        await context_hook(ctx)
+
+        assert "system_prompt" in ctx.extras
+        assert ctx.extras["system_prompt"] is not None
+
+    async def test_does_not_store_system_prompt_when_all_files_empty(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager
+    ) -> None:
+        """AC: Hook does NOT store system_prompt when all files empty."""
+        ws = settings_manager.settings.workspace
+        context_path = ws.path / CONTEXT_DIR_NAME
+        context_path.mkdir(parents=True)
+
+        (context_path / "SOUL.md").write_text("")
+        (context_path / "USER.md").write_text("")
+        (context_path / "AGENTS.md").write_text("")
+
+        await context_hook(ctx)
+
+        assert "system_prompt" not in ctx.extras
+
+    async def test_dir_creation_failure_propagates(self, ctx: BootstrapContext, mocker) -> None:
+        """AC: Dir creation failure → exception propagates (not caught)."""
+        mocker.patch.object(Path, "mkdir", side_effect=PermissionError("No perms"))
+
+        with pytest.raises(PermissionError):
+            await context_hook(ctx)
+
+
+class TestDefaultContent:
+    """Tests for the default template content constants."""
+
+    def test_soul_content_contains_personality_keywords(self) -> None:
+        """AC: DEFAULT_SOUL_CONTENT contains personality/dialogue encouragement keywords."""
+        assert "proactive" in DEFAULT_SOUL_CONTENT.lower()
+        assert "assistant" in DEFAULT_SOUL_CONTENT.lower()
+
+    def test_user_content_contains_user_discovery_prompt(self) -> None:
+        """AC: DEFAULT_USER_CONTENT contains user-discovery prompt."""
+        content_lower = DEFAULT_USER_CONTENT.lower()
+        # Should prompt the assistant to learn about the user
+        assert "ask" in content_lower or "learn" in content_lower
+
+    def test_agents_content_explains_purpose(self) -> None:
+        """AC: DEFAULT_AGENTS_CONTENT explains its purpose."""
+        content_lower = DEFAULT_AGENTS_CONTENT.lower()
+        assert "behavior" in content_lower or "instruction" in content_lower
+
+    def test_context_files_ordered_correctly(self) -> None:
+        """AC: CONTEXT_FILES has correct order: SOUL, USER, AGENTS."""
+        assert len(CONTEXT_FILES) == 3
+        assert CONTEXT_FILES[0][0] == "SOUL.md"
+        assert CONTEXT_FILES[1][0] == "USER.md"
+        assert CONTEXT_FILES[2][0] == "AGENTS.md"
+
+    def test_context_files_have_correct_xml_tags(self) -> None:
+        """AC: CONTEXT_FILES has correct XML tags."""
+        assert CONTEXT_FILES[0][1] == "soul"
+        assert CONTEXT_FILES[1][1] == "user"
+        assert CONTEXT_FILES[2][1] == "agents"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -86,9 +86,11 @@ class TestCoordinatorSendMessage:
     async def test_yields_tool_activity_for_tool_use(self, mock_sdk) -> None:
         client, _ = mock_sdk
         client.receive_messages.return_value = _mock_messages(
-            make_assistant([
-                ToolUseBlock(id="t1", name="Read", input={"file_path": "main.py"}),
-            ]),
+            make_assistant(
+                [
+                    ToolUseBlock(id="t1", name="Read", input={"file_path": "main.py"}),
+                ]
+            ),
             make_result(),
         )
 
@@ -364,3 +366,47 @@ class TestTranscriptPathDerivation:
 
         home = str(Path.home())
         assert result == f"{home}/.claude/projects/a-b-c-d/deep-sess.jsonl"
+
+
+class TestCoordinatorSystemPrompt:
+    """Tests for DLT-005: system prompt integration in the coordinator."""
+
+    async def test_system_prompt_provided_sets_sdk_system_prompt(
+        self, mock_sdk
+    ) -> None:
+        """AC: Given system_prompt is provided → system_prompt is a SystemPromptPreset."""
+        _, mock_cls = mock_sdk
+
+        async with Coordinator(system_prompt="Custom prompt"):
+            pass
+
+        options = mock_cls.call_args[0][0]
+        assert options.system_prompt is not None
+        assert options.system_prompt["type"] == "preset"
+        assert options.system_prompt["preset"] == "claude_code"
+        assert options.system_prompt["append"] == "Custom prompt"
+
+    async def test_system_prompt_none_leaves_unset(
+        self, mock_sdk
+    ) -> None:
+        """AC: Given system_prompt is None → ClaudeAgentOptions.system_prompt is None."""
+        _, mock_cls = mock_sdk
+
+        async with Coordinator():
+            pass
+        options = mock_cls.call_args[0][0]
+        assert options.system_prompt is None
+
+    async def test_system_prompt_does_not_break_send_message(self, mock_sdk) -> None:
+        """AC: Given system_prompt is provided → existing coordinator behavior still works."""
+        client, _ = mock_sdk
+        client.receive_messages.return_value = _mock_messages(
+            make_assistant([TextBlock(text="Hello!")]),
+            make_result(),
+        )
+        async with Coordinator(system_prompt="Custom prompt") as coord:
+            events = [e async for e in coord.send_message("hi")]
+
+        text_events = [e for e in events if isinstance(e, TextChunk)]
+        assert len(text_events) == 1
+        assert text_events[0].text == "Hello!"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,73 @@
+"""Workspace initialization hook tests.
+
+Tests for DLT-023: Bootstrap agent workspace on first run.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tachikoma.bootstrap import BootstrapContext
+from tachikoma.config import SettingsManager
+from tachikoma.workspace import workspace_hook
+
+
+class TestWorkspaceHook:
+    """Tests for the workspace initialization hook."""
+
+    @pytest.fixture
+    def ctx(self, settings_manager: SettingsManager) -> BootstrapContext:
+        return BootstrapContext(settings_manager=settings_manager, prompt=input)
+
+    async def test_creates_workspace_and_data_dir(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager,
+    ) -> None:
+        """AC (R0, R1): No dirs exist, both workspace and .tachikoma/ are created."""
+        await workspace_hook(ctx)
+
+        ws = settings_manager.settings.workspace
+
+        assert ws.path.is_dir()
+        assert ws.data_path.is_dir()
+
+    async def test_skips_when_workspace_exists(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager,
+    ) -> None:
+        """AC (R7): Dirs already exist, no error on re-run."""
+        ws = settings_manager.settings.workspace
+        ws.path.mkdir(parents=True)
+        ws.data_path.mkdir()
+
+        await workspace_hook(ctx)
+
+        assert ws.path.is_dir()
+        assert ws.data_path.is_dir()
+
+    async def test_creates_data_dir_when_workspace_exists(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager,
+    ) -> None:
+        """AC (R1): Workspace exists but .tachikoma/ doesn't, creates it."""
+        ws = settings_manager.settings.workspace
+        ws.path.mkdir(parents=True)
+
+        await workspace_hook(ctx)
+
+        assert ws.data_path.is_dir()
+
+    async def test_raises_when_path_is_file(
+        self, ctx: BootstrapContext, settings_manager: SettingsManager,
+    ) -> None:
+        """AC (R9): Workspace path is a file, raises with clear error."""
+        ws = settings_manager.settings.workspace
+        ws.path.parent.mkdir(parents=True, exist_ok=True)
+        ws.path.touch()
+
+        with pytest.raises(RuntimeError, match="not a directory"):
+            await workspace_hook(ctx)
+
+    async def test_raises_on_permission_error(self, ctx: BootstrapContext, mocker) -> None:
+        """AC (R9): mkdir fails with PermissionError, raises with clear message."""
+        mocker.patch.object(Path, "mkdir", side_effect=PermissionError)
+
+        with pytest.raises(RuntimeError, match="Permission denied"):
+            await workspace_hook(ctx)


### PR DESCRIPTION
# [DLT-005] Load foundational context for personality and user knowledge

**Current phase:** implement (✓ complete)

<details><summary><h2>Spec</h2></summary>

# Delta Spec: DLT-005 - Load foundational context for personality and user knowledge

## Story

As a user, I want the assistant to have a consistent personality, know about me, and follow operational guidelines so that interactions feel natural and personalized regardless of which memories are retrieved.

## What It Does

Three markdown files in a `context/` subdirectory of the workspace establish the assistant's identity and baseline knowledge: SOUL.md defines personality and tone, USER.md captures known information about the user, and AGENTS.md provides behavioral instructions that don't fit the other two files. A bootstrap hook creates default template files on first run. At startup, a context loader reads these files and assembles them into an appended system prompt — preceded by a hard-coded preamble that explains the context system to the agent. The assembled prompt is passed to the Claude Agent SDK, preserving the SDK's default instructions while layering on custom context. Missing, empty, or unreadable files are handled gracefully — the assistant starts without that context rather than crashing.

## Requirements

| ID | Requirement | Status |
|----|-------------|--------|
| R0 | Provide the assistant with foundational, always-available context through core files loaded into the system prompt | Core goal |
| R1 | Three core context files as human-readable markdown in `context/` subdirectory: SOUL.md (personality/tone), USER.md (user knowledge), AGENTS.md (behavioral instructions that don't fit SOUL or USER) | Must-have |
| R2 | Context layered on top of the SDK's default system prompt without replacing it | Must-have |
| R3 | Bootstrap hook creates `context/` directory and default template files on first run (idempotent) | Must-have |
| R4 | Graceful handling when files are missing, empty, or unreadable — log a warning but continue without crashing | Must-have |
| R5 | Default SOUL.md has a starter personality encouraging an initial dialogue with the user to understand their expectations | Must-have |
| R5.1 | Default USER.md has a paragraph prompting the assistant to ask the user about themselves and fill in the file | Must-have |
| R5.2 | Default AGENTS.md explains its purpose as a place for behavioral instructions that don't fit SOUL or USER | Must-have |
| R6 | Context loaded once during bootstrap and passed to the coordinator at startup | Must-have |
| R7 | Hard-coded preamble in code explains the context system to the agent before the file contents | Must-have |
| R8 | Per-session context reload on session restart | Out (deferred to session restart delta) |
| R9 | Hot-reload of context files mid-session | Out |

## Acceptance Criteria

### Bootstrap hook (R3, R1)

- [ ] Given no `context/` directory in workspace, when the context bootstrap hook runs, then the directory is created along with SOUL.md, USER.md, and AGENTS.md with default content
- [ ] Given `context/` directory and all three files already exist, when the hook runs, then nothing is changed (idempotent)
- [ ] Given `context/` directory exists but one file is missing, when the hook runs, then only the missing file is created with default content
- [ ] Given the bootstrap system, when hooks are registered, then the context hook is registered after the workspace hook (depends on workspace directory existing)

### Default template content (R5, R5.1, R5.2)

- [ ] Given the bootstrap hook creates SOUL.md, then it contains a starter personality with guidelines encouraging an initial conversation with the user to understand their expectations and preferences
- [ ] Given the bootstrap hook creates USER.md, then it contains a paragraph prompting the assistant to ask the user about themselves and populate the file over time
- [ ] Given the bootstrap hook creates AGENTS.md, then it explains its purpose as a place for behavioral instructions that don't fit SOUL or USER, with examples of what might go here

### Context loading and assembly (R0, R2, R6, R7)

- [ ] Given all three context files exist with content, when bootstrap runs, then the files are read and assembled into an appended system prompt that preserves the SDK's default prompt
- [ ] Given context files are loaded, when the assembled prompt is built, then a hard-coded preamble explaining the context system is placed before the file contents
- [ ] Given the files are concatenated, then the ordering is: SOUL.md first (personality), then USER.md (user knowledge), then AGENTS.md last (behavioral instructions)
- [ ] Given context files are loaded, when the coordinator is created, then the system prompt includes the SDK default instructions, the hard-coded preamble, and the context file contents
- [ ] Given context is loaded at startup, when the user edits a context file mid-session, then the changes are NOT reflected until the next startup

### Graceful degradation (R4)

- [ ] Given one or more context files are missing at startup, when context loading runs, then a warning is logged for each missing file and available files are still loaded
- [ ] Given all context files are empty, when context loading runs, then the coordinator starts with only the hard-coded preamble appended (no file content)
- [ ] Given all context files are missing, when context loading runs, then the coordinator starts with only the hard-coded preamble appended (no file content)
- [ ] Given a context file exists but cannot be read (e.g., permission denied), when context loading runs, then a warning is logged for the unreadable file and available files are still loaded

### Transparency (R1)

- [ ] Given the context files exist, when the user navigates to the workspace `context/` directory, then they can see and edit SOUL.md, USER.md, and AGENTS.md in any text editor
- [ ] Given a user edits a context file and restarts the app, then the agent uses the updated content

## Requires

Dependencies:
- None

---

## Detected Impacts

### Affected Features
- **docs/feature-specs/agent/core-architecture.md** — Modifies: Coordinator now receives a system prompt parameter; ClaudeAgentOptions configuration expands to include system_prompt
- **docs/feature-specs/agent/workspace-bootstrap.md** — Adds: New bootstrap hook for context directory and file initialization

### Notes for Reconciliation
- Core architecture spec needs to document the system_prompt parameter on Coordinator and its flow into SDK options
- Workspace bootstrap spec needs a new hook entry for the context initialization hook
- A new feature spec may be needed for the "core context" capability domain under `docs/feature-specs/agent/`
- DLT-018 (update core context files) will modify these same files — it consumes whatever format is established here

</details>

<details><summary><h2>Design</h2></summary>

# Design: DLT-005 - Load foundational context for personality and user knowledge

**Delta Spec**: [../delta-specs/DLT-005.md](../delta-specs/DLT-005.md)
**Status**: Approved

## Purpose

This document explains the design rationale for this delta: the modeling choices, data flow, system behavior, and architectural approach.

After implementation, the "Detected Impacts" section will guide reconciliation into feature design docs.

## Problem Context

The assistant needs a consistent personality, knowledge of the user, and operational guidelines — regardless of which memories are retrieved for a given conversation. Without foundational context, the agent starts each session as a blank slate, relying entirely on dynamically retrieved memories (future DLT-006) for personality and user knowledge.

Three concerns drive the design:

1. **Identity consistency**: The agent should have the same tone, personality, and behavioral guidelines every time
2. **User knowledge baseline**: Known facts about the user (name, preferences, projects) should always be available, not contingent on memory retrieval relevance
3. **Transparency**: Users should be able to see and edit exactly what shapes the agent's behavior — no hidden configuration

**Constraints:**
- Context files must be human-readable markdown in the workspace (user-editable)
- Context is layered ON TOP of the SDK's default Claude Code system prompt, not replacing it
- Files are loaded once at startup — no hot-reload mid-session (R8, R9 are Out)
- Bootstrap hook must be idempotent (safe to run every launch)

**Interactions:**
- Workspace bootstrap (DLT-023) must run first to create the workspace directory
- DLT-018 (update core context files from conversations) will consume the file paths and format established here
- The coordinator (core architecture) receives the assembled prompt as a constructor parameter

## Design Overview

A new `context.py` module owns the entire context domain: file path definitions, default template content, a bootstrap hook for first-run initialization, and a loader that reads and assembles files into a system prompt string. The hook creates `context/` and writes default templates on first run, then loads the files and stores the assembled prompt in `ctx.extras["system_prompt"]`. The entry point reads this extra and passes it to the Coordinator, which wraps it in a `SystemPromptPreset` to append it to the SDK's default Claude Code prompt.

As part of this delta, `workspace_hook` is extracted from `bootstrap.py` into a new `workspace.py` module, establishing the pattern that each subsystem owns its bootstrap hook internally. `bootstrap.py` becomes purely the mechanism.

```
┌──────────────────────────────────────────────────────────────────┐
│                          __main__.py                              │
│                                                                  │
│  bootstrap.register("workspace", workspace_hook)  ← workspace.py │
│  bootstrap.register("context", context_hook)      ← context.py   │
│  bootstrap.register("sessions", session_recovery_hook)            │
│                                                                  │
│  await bootstrap.run()                                           │
│                                                                  │
│  system_prompt = bootstrap.extras.get("system_prompt")           │
│  Coordinator(..., system_prompt=system_prompt)                    │
└──────────────────────────────────────────────────────────────────┘
```

## Shape

| Part | Mechanism | Flag |
|------|-----------|:----:|
| **S1** | **Context bootstrap hook** — A `context_hook` function in a new `context.py` module that creates `context/` directory under workspace root and writes default template files (SOUL.md, USER.md, AGENTS.md) on first run. Skips existing files. Registered after workspace hook in `__main__.py`. | |
| **S2** | **Context loader** — A `load_context` function in `context.py` that reads the three context files, handles missing/empty/unreadable files gracefully (logs warnings per DES-002), prepends a hard-coded preamble explaining the context system, and concatenates file contents wrapped in XML tags (`<soul>`, `<user>`, `<agents>`) in order: SOUL → USER → AGENTS. Returns the assembled string. Called by the hook, result stored in `ctx.extras["system_prompt"]`. | |
| **S3** | **Coordinator system prompt integration** — Coordinator accepts a `system_prompt: str | None` parameter. When present, wraps it in `SystemPromptPreset(type="preset", preset="claude_code", append=context_string)` and sets it on `ClaudeAgentOptions.system_prompt`. `__main__.py` reads `bootstrap.extras["system_prompt"]` and passes to Coordinator. | |
| **S4** | **Default template content** — Meaningful starter content as module-level constants in `context.py`: SOUL.md with personality traits + dialogue encouragement, USER.md with user-discovery prompt, AGENTS.md explaining its purpose as behavioral instructions. | |
| **S5** | **Workspace hook extraction** — Move `workspace_hook` from `bootstrap.py` to a new `workspace.py` module. Update imports in `__main__.py`. Establishes the pattern: each subsystem owns its hook internally. `bootstrap.py` becomes purely the mechanism (Bootstrap class, BootstrapContext, BootstrapError, BootstrapHook type). | |

### Flagged Unknowns

None.

## Components

### Implementation Structure

| Layer/Component | Responsibility | Key Decisions |
|-----------------|----------------|---------------|
| `src/tachikoma/context.py` | Context file management: file path definitions, default template constants, bootstrap hook (`context_hook`), and context loader (`load_context`) | New module; single home for the context domain. DLT-018 will import from here. |
| `src/tachikoma/workspace.py` | Workspace directory creation hook (`workspace_hook`) | Extracted from `bootstrap.py`; owns the workspace initialization concern |
| `src/tachikoma/bootstrap.py` | Bootstrap mechanism only: `Bootstrap`, `BootstrapContext`, `BootstrapHook`, `BootstrapError` | `workspace_hook` removed; purely mechanism now |
| `src/tachikoma/coordinator.py` | Wraps `ClaudeSDKClient`; now accepts `system_prompt` parameter | `SystemPromptPreset` integration via `ClaudeAgentOptions.system_prompt` |
| `src/tachikoma/__main__.py` | Entry point: registers hooks, reads `system_prompt` from extras, passes to Coordinator | Hook registration order: workspace → context → sessions |

### Cross-Layer Contracts

```mermaid
sequenceDiagram
    participant Main as __main__.py
    participant Boot as Bootstrap
    participant WH as workspace_hook
    participant CH as context_hook
    participant Loader as load_context
    participant Coord as Coordinator
    participant SDK as ClaudeSDKClient

    Main->>Boot: register("workspace", workspace_hook)
    Main->>Boot: register("context", context_hook)
    Main->>Boot: register("sessions", session_recovery_hook)
    Main->>Boot: await run()

    Boot->>WH: workspace_hook(ctx)
    WH-->>Boot: workspace dir ready

    Boot->>CH: context_hook(ctx)
    CH->>CH: create context/ dir + default files (if missing)
    CH->>Loader: load_context(workspace_path)
    Loader-->>CH: assembled prompt string (or None)
    CH->>CH: ctx.extras["system_prompt"] = prompt
    CH-->>Boot: done

    Boot-->>Main: run() complete

    Main->>Main: system_prompt = bootstrap.extras.get("system_prompt")
    Main->>Coord: Coordinator(..., system_prompt=system_prompt)
    Coord->>SDK: ClaudeAgentOptions(system_prompt=SystemPromptPreset(..., append=system_prompt))
```

**Integration Points:**
- context_hook ↔ Bootstrap: receives `BootstrapContext`, stores result in `ctx.extras["system_prompt"]`
- `__main__.py` ↔ Bootstrap: reads `bootstrap.extras.get("system_prompt")` after `run()`
- `__main__.py` ↔ Coordinator: passes `system_prompt` string to constructor
- Coordinator ↔ SDK: wraps string in `SystemPromptPreset` and sets on `ClaudeAgentOptions`

### Shared Logic

- **Context file paths**: Defined in `context.py` as functions of the workspace path. DLT-018 will import these to know where to write updates.
- **Default template content**: Module-level string constants in `context.py`. DLT-018 may reference these for understanding the file format.

## Modeling

The domain model is minimal — this delta introduces no persistent entities:

```
context.py
├── CONTEXT_DIR_NAME = "context"
├── CONTEXT_FILES: ordered list mapping filename → XML tag name → default content
│   ├── ("SOUL.md",   "soul",   DEFAULT_SOUL_CONTENT)
│   ├── ("USER.md",   "user",   DEFAULT_USER_CONTENT)
│   └── ("AGENTS.md", "agents", DEFAULT_AGENTS_CONTENT)
├── CONTEXT_PREAMBLE (str constant)
├── context_hook(ctx: BootstrapContext) → None
└── load_context(workspace_path: Path) → str | None
```

The three context files are plain markdown managed by the user. The system reads them as strings and assembles them into a single prompt string. No structured parsing, no metadata extraction — just string concatenation with XML delimiters.

`load_context` returns `str | None`: a non-empty assembled string when at least one file has content, or `None` when all files are missing/empty (so the coordinator can skip setting the system prompt entirely).

## Data Flow

### Bootstrap flow (context initialization)

```
1. context_hook receives BootstrapContext
2. Reads workspace_path from ctx.settings_manager.settings.workspace.path
3. Computes context_path = workspace_path / "context"
4. Creates context_path directory if missing (exist_ok=True)
5. For each of [SOUL.md, USER.md, AGENTS.md]:
   a. Check if file exists at context_path / filename
   b. If missing → write default template content
   c. If exists → skip (idempotent)
6. Calls load_context(workspace_path) to assemble the prompt
7. If result is not None → stores in ctx.extras["system_prompt"]
```

### Context loading and assembly

```
1. load_context receives workspace_path
2. Computes context_path = workspace_path / "context"
3. For each file in order (SOUL.md, USER.md, AGENTS.md):
   a. Attempt to read file contents
   b. If missing → log warning, skip
   c. If empty → skip (no section added, no warning)
   d. If unreadable (PermissionError, OSError) → log warning, skip
   e. If has content → wrap in XML tags and collect
4. If no sections collected → return None
5. Prepend hard-coded preamble to collected sections
6. Return assembled string
```

### Assembled prompt structure

```
[CONTEXT_PREAMBLE — explains the context system, file purposes, user-editability]

<soul>
[contents of SOUL.md]
</soul>

<user>
[contents of USER.md]
</user>

<agents>
[contents of AGENTS.md]
</agents>
```

### Startup flow (how prompt reaches the agent)

```
1. __main__.py registers hooks: workspace → context → sessions
2. Bootstrap.run() executes hooks in order
3. After run(), __main__.py reads bootstrap.extras.get("system_prompt")
4. Passes system_prompt to Coordinator constructor
5. Coordinator stores system_prompt
6. On __aenter__, creates ClaudeSDKClient with options:
   - If system_prompt is not None:
     SystemPromptPreset(type="preset", preset="claude_code", append=system_prompt)
   - If system_prompt is None:
     system_prompt field left as None (SDK default)
7. ClaudeSDKClient receives options with appended context
```

## Key Decisions

### Subsystem-owned hooks (pattern change)

**Choice**: Each subsystem defines its own bootstrap hook in its own module. `workspace_hook` moves to `workspace.py`, `context_hook` lives in `context.py`, `session_recovery_hook` already lives in `sessions/hooks.py`.
**Why**: Separation of concerns — `bootstrap.py` should be the mechanism, not a bag of unrelated hooks. Each subsystem owns its initialization logic. This also gives downstream deltas (DLT-018, DLT-020) clean import targets.
**Sources**: User decision during design interview; sessions package already follows this pattern.
**Options Researched**: Co-locating all hooks in `bootstrap.py` (simpler but conflates mechanism with concerns).
**Why This Over Alternatives**: Consistency with existing sessions pattern; cleaner module boundaries; better for DLT-018 reuse.

**Consequences**:
- Pro: Clean module boundaries — each subsystem is self-contained
- Pro: `bootstrap.py` stays focused and small
- Pro: DLT-018 can import `context.py` directly
- Con: One more module per subsystem (minor; each is small)

### XML tags for section delimiters

**Choice**: Wrap each file's content in XML tags (`<soul>`, `<user>`, `<agents>`) in the assembled prompt.
**Why**: XML tags provide clear, unambiguous boundaries that LLMs can reliably parse. They are commonly used in system prompts to delineate sections and are less likely to be confused with file content than markdown headings.
**Sources**: User decision during design interview; common LLM prompt engineering practice.
**Options Researched**: Markdown headings (`# SOUL`), simple separators (`---`), XML tags.
**Why This Over Alternatives**: Markdown headings could collide with content in the files themselves. Simple separators lack semantic meaning. XML tags are explicit and widely used for prompt section delineation.

**Consequences**:
- Pro: Unambiguous section boundaries
- Pro: Agent can easily reference "the content in `<soul>`" for self-awareness
- Con: Slightly more verbose than markdown headings (negligible)

### SystemPromptPreset with append (not replace)

**Choice**: Use `SystemPromptPreset(type="preset", preset="claude_code", append=context_string)` to layer context on top of the SDK's default prompt.
**Why**: The SDK's default Claude Code prompt includes tool-use instructions, safety guidelines, and agentic loop behaviors that are essential for the agent to function correctly. Replacing it would require replicating all of that. Appending is the SDK's designed mechanism for this use case.
**Sources**: SDK source code inspection — `ClaudeAgentOptions.system_prompt` accepts `str | SystemPromptPreset | None`; `SystemPromptPreset` is a `TypedDict` with `type`, `preset`, and `append` fields. Importable from `claude_agent_sdk.types`.
**Options Researched**: Full replacement via plain string, `SystemPromptPreset` with append.
**Why This Over Alternatives**: Full replacement loses all SDK built-in behaviors (tool use, safety, agentic loop). Append preserves them and is the intended extension mechanism.

**Consequences**:
- Pro: Preserves all SDK default behaviors
- Pro: Uses the SDK's designed extension point
- Pro: Future SDK updates to the default prompt automatically apply
- Con: We don't control the full system prompt (acceptable — we shouldn't)

### Context loader returns None for empty state

**Choice**: `load_context` returns `str | None` — `None` when all files are missing or empty.
**Why**: When no context files have content, there's nothing to append. Returning `None` lets the coordinator skip setting `system_prompt` entirely, which means the SDK uses its vanilla default prompt. This avoids appending just the preamble with no actual content.

**Consequences**:
- Pro: Clean no-op when no context exists
- Pro: Coordinator doesn't need to check for empty strings
- Con: None (the distinction is clear)

### Empty files are silent, missing/unreadable files warn

**Choice**: Empty files are silently skipped (no warning), while missing and unreadable files log a warning.
**Why**: The spec's R4 groups "missing, empty, or unreadable" together, but the conditions have different semantics. A missing file is unexpected after the bootstrap hook has run (something deleted it). An unreadable file is an OS-level error. Both warrant a warning. An empty file, however, is a deliberate user action — the user opened the file and removed all content, or explicitly chose not to fill it in. Warning on intentional behavior would be noisy. This design refines R4's blanket treatment into context-appropriate handling.

**Consequences**:
- Pro: No false alarms for intentional user choices
- Pro: Warnings still fire for genuinely unexpected conditions (missing, permissions)
- Con: Slight divergence from R4 wording (but aligns with R4's intent)

### Fatal vs graceful error boundary

**Choice**: Directory creation failures in `context_hook` are fatal (abort startup via BootstrapError). File read failures in `load_context` are graceful (log and continue).
**Why**: If the `context/` directory cannot be created, something is fundamentally wrong with the filesystem — the same class of failure that makes `workspace_hook` fatal. The agent cannot function if basic directory operations fail. File read failures, on the other hand, are localized — one unreadable file should not prevent the agent from starting with the remaining files.

**Consequences**:
- Pro: Consistent with workspace_hook behavior for directory-level failures
- Pro: File-level failures degrade gracefully per R4
- Con: None (clear boundary between infrastructure failure and content failure)

## System Behavior

### Scenario: First launch — no context directory

**Given**: The workspace exists but no `context/` directory
**When**: The context hook runs during bootstrap
**Then**: `context/` is created along with SOUL.md, USER.md, and AGENTS.md containing default template content. The loader reads all three files and assembles the system prompt with the preamble and XML-tagged sections.
**Rationale**: First-run initialization creates meaningful defaults that prompt the agent to engage in a personality/preference discovery conversation with the user.

### Scenario: Subsequent launch — all files exist and have content

**Given**: All three context files exist with user-customized content
**When**: The context hook runs
**Then**: The hook skips file creation (idempotent). The loader reads files and assembles the system prompt with the user's content.
**Rationale**: Idempotency — existing files are never overwritten.

### Scenario: One context file is missing

**Given**: SOUL.md and AGENTS.md exist, but USER.md was accidentally deleted
**When**: The context hook runs
**Then**: The hook recreates USER.md with default content. The loader reads all three files.
**Rationale**: Per R3 (AC: only missing file is created with default content) — selective creation preserves existing files while recovering missing ones.

### Scenario: One context file is empty

**Given**: All three files exist, but USER.md is empty (0 bytes)
**When**: The loader reads context files
**Then**: SOUL.md and AGENTS.md are wrapped in XML tags; USER.md is skipped (no `<user>` section in output). No warning is logged for empty files.
**Rationale**: An empty file is a deliberate user action, not an error. The system respects it by omitting that section.

### Scenario: Context file is unreadable (permission denied)

**Given**: SOUL.md exists but has no read permissions
**When**: The loader attempts to read it
**Then**: A warning is logged per DES-002 (`component="context"`, level=WARNING), SOUL.md is skipped, remaining files are loaded normally.
**Rationale**: Per R4 — graceful degradation. The agent starts with partial context rather than crashing.

### Scenario: All files are missing or empty

**Given**: The context directory exists but all files are missing or empty
**When**: The loader runs
**Then**: No sections are collected, `load_context` returns `None`. The coordinator starts without a custom system prompt (SDK default only). The preamble is NOT appended when there's no content.
**Rationale**: Avoids appending a meaningless preamble with no actual context.

### Scenario: User edits a context file between sessions

**Given**: The user modifies SOUL.md between app restarts
**When**: The app restarts and the context hook runs
**Then**: The loader reads the updated SOUL.md content. The agent uses the updated personality.
**Rationale**: Per R6 — context is loaded once at startup. Changes are reflected on restart.

### Scenario: User edits a context file mid-session

**Given**: The user modifies SOUL.md while the agent is running
**When**: The user continues the conversation
**Then**: The agent continues using the old SOUL.md content loaded at startup. Changes take effect on next restart.
**Rationale**: Per R9 (Out) — hot-reload is explicitly deferred. Per AC: "when the user edits a context file mid-session, then the changes are NOT reflected until the next startup."

## Open Questions

None — all design decisions resolved.

---

## Detected Impacts

### Affected Feature Designs
- **docs/feature-designs/agent/core-architecture.md** — Modifies: Coordinator constructor gains `system_prompt` parameter; `ClaudeAgentOptions` configuration expands to include `system_prompt` via `SystemPromptPreset`
- **docs/feature-designs/agent/workspace-bootstrap.md** — Modifies: `workspace_hook` moves from `bootstrap.py` to `workspace.py`; `bootstrap.py` becomes purely mechanism; subsystem-owned hook pattern established
- **docs/feature-designs/agent/README.md** — Adds: May need a new "core-context" sub-capability entry

### Notes for Reconciliation
- Core architecture design needs to document the `system_prompt` parameter on Coordinator and its flow into SDK options
- Workspace bootstrap design needs updating: `workspace_hook` location changed from `bootstrap.py` to `workspace.py`
- Bootstrap Components table needs updating — `workspace_hook` removed from `bootstrap.py` responsibility
- A new feature design doc may be needed for the "core-context" capability domain under `docs/feature-designs/agent/`
- DLT-018 (update core context files) will consume `context.py` exports — the module API established here is the contract

## Notes
- The `SystemPromptPreset` type is importable from `claude_agent_sdk.types`, not from the top-level `claude_agent_sdk` package
- The preamble content should be concise — the agent already understands markdown and XML. It needs to know: what the files are, that they're user-editable, and what each file's purpose is
- Default template content (S4) should be thoughtful but brief — lengthy defaults waste context tokens on every session until the user customizes them
- **Emptiness check**: Files should be considered "empty" when their stripped content is empty (i.e., `content.strip() == ""`). A file containing only whitespace is effectively empty and should be treated the same as a zero-byte file.
- **CONTEXT_FILES type**: The ordered mapping of (filename, xml_tag, default_content) can be a `list[tuple[str, str, str]]` or a similar structure — left to implementer's discretion

</details>

## Plan

# Implementation Plan: DLT-005

**Delta Spec**: [../delta-specs/DLT-005.md](../delta-specs/DLT-005.md)
**Delta Design**: [../delta-designs/DLT-005.md](../delta-designs/DLT-005.md)

## Batch 1: Workspace Hook Extraction (S5) — ✓ Done
Depends on: — (none)

### Context & Research
- `src/tachikoma/bootstrap.py` — Source of the extraction; contains `workspace_hook` (lines 60-82) and the mechanism classes
- `src/tachikoma/__main__.py` — Imports `workspace_hook` from `bootstrap`; import path changes to `workspace`
- `src/tachikoma/sessions/hooks.py` — Reference pattern: subsystem-owned hook in its own module
- `tests/test_bootstrap.py` — Contains `TestWorkspaceHook` class and `settings_manager` fixture; imports must update, tests move to new file
- `tests/conftest.py` — May need the `settings_manager` fixture extracted here if shared across test files
- DLT-005 Design § "Subsystem-owned hooks" — Design decision and rationale

### Steps

#### Step 1: Create `workspace.py` with extracted hook

- Create: `src/tachikoma/workspace.py`
- What to do: Move `workspace_hook` function from `bootstrap.py` to a new `workspace.py` module. Include the necessary imports (`BootstrapContext` from `bootstrap`). Keep the function signature and implementation identical.
- Test: Module imports successfully; `workspace_hook` is importable from `tachikoma.workspace`

```python
# In src/tachikoma/workspace.py:
# Move workspace_hook here from bootstrap.py
# Import BootstrapContext from tachikoma.bootstrap
# Keep identical function body
```

#### Step 2: Remove `workspace_hook` from `bootstrap.py`

- Modify: `src/tachikoma/bootstrap.py`
- What to do: Remove the `workspace_hook` function and any imports that were only used by it. The module should contain only: `BootstrapError`, `BootstrapContext`, `BootstrapHook` type alias, and `Bootstrap` class.
- Test: `bootstrap.py` no longer exports `workspace_hook`; all mechanism classes still importable

#### Step 3: Update `__main__.py` imports

- Modify: `src/tachikoma/__main__.py`
- What to do: Change import to get `workspace_hook` from `tachikoma.workspace` instead of `tachikoma.bootstrap`.
- Test: Application starts successfully with the new import paths

```python
# In src/tachikoma/__main__.py:
from tachikoma.bootstrap import Bootstrap, BootstrapError
from tachikoma.workspace import workspace_hook  # moved from bootstrap
```

#### Step 4: Move workspace hook tests to `test_workspace.py`

- Create: `tests/test_workspace.py`
- Modify: `tests/test_bootstrap.py`
- What to do: Move `TestWorkspaceHook` class to a new `tests/test_workspace.py` file to mirror the source module structure per DES-001. Update imports to use `from tachikoma.workspace import workspace_hook`. The `settings_manager` fixture (currently defined in `test_bootstrap.py`) is needed by both `TestBootstrap` and `TestWorkspaceHook` — extract it to `tests/conftest.py` so both test files can access it. Remove it from `test_bootstrap.py`.
- Test: `uv run pytest tests/test_bootstrap.py tests/test_workspace.py -v` — all tests pass

#### Step 5: Verify Batch 1

- Run: `uv run pytest -x` — full test suite passes
- Verify: `bootstrap.py` only contains mechanism code (Bootstrap, BootstrapContext, BootstrapHook, BootstrapError)
- Verify: `workspace.py` contains `workspace_hook`
- Verify: `__main__.py` imports from correct modules

---

## Batch 2: Context Module — Hook, Loader & Templates (S1, S2, S4) — ✓ Done
Depends on: Batch 1

### Context & Research
- DLT-005 Spec §R1-R7 + Acceptance Criteria — File structure, bootstrap behavior, graceful degradation, ordering requirements
- DLT-005 Design §S1, §S2, §S4, §Modeling, §Data Flow — Hook logic, loader algorithm, file-to-XML-tag mapping, return type, emptiness semantics
- DLT-005 Design § "Empty files are silent, missing/unreadable files warn" — Key decision on warning behavior
- DLT-005 Design § "Fatal vs graceful error boundary" — Dir failures fatal, file read failures graceful
- DLT-005 Design §Notes — `content.strip() == ""` for emptiness, preamble concise, CONTEXT_FILES type flexible
- `src/tachikoma/workspace.py` (from Batch 1) — Pattern reference: freshly established subsystem-owned hook
- `src/tachikoma/sessions/hooks.py` — Pattern reference: subsystem hook reads settings, creates resources, stores in `ctx.extras`
- DES-002 (Logging Conventions) — `logger.bind(component="context")`, structured messages, WARNING level for missing/unreadable files
- `src/tachikoma/bootstrap.py` (from Batch 1) — `BootstrapContext` interface: `ctx.settings_manager.settings.workspace.path`, `ctx.extras`
- `src/tachikoma/__main__.py` (from Batch 1) — Hook registration site; context hook registered after workspace hook

### Steps

#### Step 6: Create `context.py` with constants and file definitions

- Create: `src/tachikoma/context.py`
- What to do: Define the module with:
  - `CONTEXT_DIR_NAME = "context"` constant
  - `CONTEXT_FILES` — ordered list of tuples `(filename, xml_tag, default_content)` for SOUL.md/soul, USER.md/user, AGENTS.md/agents
  - `CONTEXT_PREAMBLE` — concise hard-coded string explaining the context system to the agent (what the files are, that they're user-editable, what each file's purpose is)
  - `DEFAULT_SOUL_CONTENT` — starter personality with traits and dialogue encouragement
  - `DEFAULT_USER_CONTENT` — paragraph prompting assistant to ask the user about themselves
  - `DEFAULT_AGENTS_CONTENT` — explains purpose as behavioral instructions with examples
  - Module-level bound logger: `_log = logger.bind(component="context")`
- Test: Module imports successfully; constants are accessible

```python
# In src/tachikoma/context.py:

# Module-level logger per DES-002
# _log = logger.bind(component="context")

# CONTEXT_DIR_NAME = "context"

# Default content constants — brief but meaningful
# DEFAULT_SOUL_CONTENT = """..."""
# DEFAULT_USER_CONTENT = """..."""
# DEFAULT_AGENTS_CONTENT = """..."""

# Ordered file definitions: (filename, xml_tag, default_content)
# CONTEXT_FILES = [
#     ("SOUL.md", "soul", DEFAULT_SOUL_CONTENT),
#     ("USER.md", "user", DEFAULT_USER_CONTENT),
#     ("AGENTS.md", "agents", DEFAULT_AGENTS_CONTENT),
# ]

# CONTEXT_PREAMBLE = """..."""  — concise explanation of the context system
```

#### Step 7: Implement `load_context` function

- Create: `src/tachikoma/context.py` (add to module from Step 6)
- What to do: Implement `load_context(workspace_path: Path) -> str | None` as a **synchronous** function (no `async`) — it only does small file reads, matching the pattern of `workspace_hook`'s synchronous I/O. Per the design's data flow:
  1. Compute `context_path = workspace_path / CONTEXT_DIR_NAME`
  2. For each file in CONTEXT_FILES order:
     - Try to read the file
     - If missing (FileNotFoundError) → log warning, skip
     - If unreadable (PermissionError, OSError) → log warning, skip
     - If empty (`content.strip() == ""`) → skip silently (no warning)
     - If has content → wrap in XML tags (`<tag>\n{content}\n</tag>`) and collect
  3. If no sections collected → return None
  4. Prepend CONTEXT_PREAMBLE to collected sections
  5. Return assembled string
- Test: Unit tests for all code paths (see Step 9)

```python
# In src/tachikoma/context.py:

# def load_context(workspace_path: Path) -> str | None:
#     """Read context files and assemble into a system prompt string.
#
#     Synchronous — files are small. Returns None when no content found.
#     """
#     context_path = workspace_path / CONTEXT_DIR_NAME
#     sections: list[str] = []
#
#     for filename, tag, _ in CONTEXT_FILES:
#         # Try to read, handle missing/unreadable/empty per design
#         # Wrap non-empty content in <tag>...</tag>
#         # Collect into sections
#
#     if not sections:
#         return None
#
#     return CONTEXT_PREAMBLE + "\n\n" + "\n\n".join(sections)
```

#### Step 8: Implement `context_hook` function

- Create: `src/tachikoma/context.py` (add to module from Steps 6-7)
- What to do: Implement `context_hook(ctx: BootstrapContext) -> None` as an async function (matching the `BootstrapHook` type). Synchronous I/O for small files is acceptable here, consistent with `workspace_hook`. Per the design's bootstrap flow:
  1. Read workspace_path from `ctx.settings_manager.settings.workspace.path`
  2. Compute `context_path = workspace_path / CONTEXT_DIR_NAME`
  3. Create context directory (`context_path.mkdir(exist_ok=True)`) — if this fails, let the exception propagate (fatal, will be caught by Bootstrap and wrapped in BootstrapError)
  4. For each file in CONTEXT_FILES: if file doesn't exist, write default content
  5. Call `load_context(workspace_path)` to assemble the prompt
  6. If result is not None, store in `ctx.extras["system_prompt"]`
- Test: Unit tests for all code paths (see Step 9)

```python
# In src/tachikoma/context.py:

# async def context_hook(ctx: BootstrapContext) -> None:
#     workspace_path = ctx.settings_manager.settings.workspace.path
#     context_path = workspace_path / CONTEXT_DIR_NAME
#
#     # Create dir — fatal on failure (propagates to BootstrapError)
#     context_path.mkdir(exist_ok=True)
#
#     # Write default files for any that are missing
#     # Call load_context and store result in ctx.extras if not None
```

#### Step 9: Write tests for context module

- Create: `tests/test_context.py`
- What to do: Write comprehensive tests covering all acceptance criteria. Use the existing test patterns (class-based, async, mocker fixture, tmp_path). Test classes:

  **TestLoadContext** — tests for the loader function:
  - All three files present with content → returns assembled string with preamble + XML sections in order
  - One file missing → warns, includes remaining files
  - One file empty → skips silently (no warning), includes remaining files
  - Whitespace-only file treated as empty (`content.strip() == ""`)
  - One file unreadable (PermissionError) → warns, includes remaining files
  - All files missing → returns None
  - All files empty → returns None (note: the design refines the AC "coordinator starts with only preamble appended" — design explicitly returns None to avoid appending a meaningless preamble with no actual context)
  - Ordering: SOUL first, USER second, AGENTS last in output
  - Preamble is prepended before any file content
  - XML tags wrap each file's content (`<soul>`, `<user>`, `<agents>`)

  **TestContextHook** — tests for the bootstrap hook:
  - No context dir → creates dir + all three files with default content
  - All files exist → nothing changed (idempotent)
  - One file missing → only that file created
  - Hook stores system_prompt in ctx.extras when files have content
  - Hook does NOT store system_prompt when all files empty
  - Dir creation failure → exception propagates (not caught)

  **TestDefaultContent** — tests for template content:
  - DEFAULT_SOUL_CONTENT contains personality/dialogue encouragement keywords
  - DEFAULT_USER_CONTENT contains user-discovery prompt
  - DEFAULT_AGENTS_CONTENT explains its purpose
- Test: `uv run pytest tests/test_context.py -v` — all tests pass

#### Step 10: Register context hook in `__main__.py`

- Modify: `src/tachikoma/__main__.py`
- What to do: Import `context_hook` from `tachikoma.context` and register it after the workspace hook:
  ```
  bootstrap.register("workspace", workspace_hook)
  bootstrap.register("context", context_hook)        # NEW
  bootstrap.register("sessions", session_recovery_hook)
  ```
  The context hook must run after workspace (needs the workspace directory to exist).
- Test: Application starts, context files are created in workspace/context/

#### Step 11: Verify Batch 2

- Run: `uv run pytest -x` — full test suite passes
- Verify: Starting the app creates `context/SOUL.md`, `context/USER.md`, `context/AGENTS.md` in workspace
- Verify: Context hook logs at appropriate levels per DES-002

---

## Batch 3: Coordinator System Prompt Integration (S3) — ✓ Done
Depends on: Batch 2

### Context & Research
- DLT-005 Design §S3, §Cross-Layer Contracts, §Startup Flow — Coordinator constructor, SystemPromptPreset wrapping, __main__.py wiring
- DLT-005 Design § "SystemPromptPreset with append" — Key decision: `preset="claude_code"` with `append`, not replacement
- DLT-005 Spec §R2, §R6 + Acceptance Criteria — Layered on SDK default, loaded once, passed at construction
- `src/tachikoma/coordinator.py` — Current constructor builds `ClaudeAgentOptions` in `__init__` (line 55); `__aenter__` passes options to `ClaudeSDKClient`
- `claude_agent_sdk.types.SystemPromptPreset` — TypedDict: `type="preset"`, `preset="claude_code"`, `append: NotRequired[str]`
- `claude_agent_sdk.types.ClaudeAgentOptions` — `system_prompt: str | SystemPromptPreset | None` field
- `tests/test_coordinator.py` — Existing patterns: `mock_sdk` fixture, how options are verified via `mock_cls.call_args`
- `src/tachikoma/__main__.py` (from Batches 1 and 2) — Where `bootstrap.extras.get("system_prompt")` is read and passed to Coordinator

### Steps

#### Step 12: Add `system_prompt` parameter to Coordinator

- Modify: `src/tachikoma/coordinator.py`
- What to do:
  1. Import `SystemPromptPreset` from `claude_agent_sdk.types`
  2. Add `system_prompt: str | None = None` parameter to `Coordinator.__init__`
  3. In `__init__`, where `ClaudeAgentOptions` is currently built (line 55): if `system_prompt` is not None, wrap it in a `SystemPromptPreset` and pass as the `system_prompt` field on the options. If None, leave it unset (SDK default).
- Test: Unit tests for both paths (see Step 13)

```python
# In src/tachikoma/coordinator.py __init__:
# Add system_prompt: str | None = None parameter
# Build SystemPromptPreset when system_prompt is provided
# Pass to ClaudeAgentOptions(system_prompt=..., ...)
```

#### Step 13: Write tests for system prompt integration

- Modify: `tests/test_coordinator.py`
- What to do: Add a new test class `TestCoordinatorSystemPrompt` with tests:
  - Given system_prompt is provided → ClaudeAgentOptions.system_prompt is a SystemPromptPreset with type="preset", preset="claude_code", and append=the provided string
  - Given system_prompt is None → ClaudeAgentOptions.system_prompt is None (SDK default)
  - Given system_prompt is provided → existing coordinator behavior (send_message, lifecycle) still works correctly
- Test: `uv run pytest tests/test_coordinator.py -v` — all tests pass

#### Step 14: Wire system prompt from bootstrap extras to Coordinator in `__main__.py`

- Modify: `src/tachikoma/__main__.py`
- What to do: After bootstrap.run(), read the system prompt from extras and pass to Coordinator:
  ```python
  system_prompt = bootstrap.extras.get("system_prompt")
  ```
  Then pass `system_prompt=system_prompt` to the Coordinator constructor alongside existing arguments.
- Test: Application starts with context loaded into the coordinator's system prompt

#### Step 15: Verify Batch 3 and full acceptance criteria

- Run: `uv run pytest -x` — full test suite passes
- Run: `uv run ty check` — type checking passes
- Run: `uv run ruff check` — linting passes
- Verify end-to-end: Application starts, context files created, system prompt assembled and passed to SDK
- Verify acceptance criteria coverage:
  - [ ] Bootstrap hook creates context dir + files (Steps 8, 9)
  - [ ] Idempotent on re-run (Step 9)
  - [ ] Missing file selectively created (Step 9)
  - [ ] Hook registered after workspace hook (Step 10)
  - [ ] Default content is meaningful (Steps 6, 9)
  - [ ] Assembled prompt has preamble + XML sections in order (Steps 7, 9)
  - [ ] SDK default prompt preserved via SystemPromptPreset (Steps 12, 13)
  - [ ] Graceful degradation for missing/empty/unreadable (Steps 7, 9)
  - [ ] Files human-readable in workspace (inherent — plain markdown)

---

## Files Changed

- [ ] `src/tachikoma/workspace.py` — New: extracted workspace_hook (Batch 1)
- [ ] `src/tachikoma/bootstrap.py` — Modified: workspace_hook removed, mechanism only (Batch 1)
- [ ] `src/tachikoma/context.py` — New: context domain module — hook, loader, constants (Batch 2)
- [ ] `src/tachikoma/coordinator.py` — Modified: system_prompt parameter + SystemPromptPreset (Batch 3)
- [ ] `src/tachikoma/__main__.py` — Modified: import paths, context hook registration, system_prompt wiring (Batches 1, 2, 3)
- [ ] `tests/conftest.py` — Modified: settings_manager fixture extracted here (Batch 1)
- [ ] `tests/test_workspace.py` — New: workspace hook tests moved from test_bootstrap.py (Batch 1)
- [ ] `tests/test_bootstrap.py` — Modified: workspace hook tests + fixture removed (Batch 1)
- [ ] `tests/test_context.py` — New: context module tests (Batch 2)
- [ ] `tests/test_coordinator.py` — Modified: system prompt integration tests added (Batch 3)

## Reconciliation Notes

After implementation, the following feature docs will need reconciliation:
- **docs/feature-specs/agent/core-architecture.md** — Add system_prompt parameter to Coordinator
- **docs/feature-specs/agent/workspace-bootstrap.md** — Add context hook entry
- **docs/feature-designs/agent/core-architecture.md** — Document SystemPromptPreset integration
- **docs/feature-designs/agent/workspace-bootstrap.md** — Update workspace_hook location, document subsystem-owned hook pattern

## Notes

[To be filled during implementation]

<!-- katachi-state
phase: reconcile
session_id:
status: running
-->